### PR TITLE
patch: typo in initial states for LSTM

### DIFF
--- a/docs/modules/lstm.md
+++ b/docs/modules/lstm.md
@@ -36,7 +36,7 @@ class LSTM(BaseModel):
         description="Refer to https://github.com/NOAA-OWP/lstm/blob/master/bmi_config_files/README.md",
     )
     elev_mean: float = Field(..., description="Catchment mean elevation (m) above sea level")
-    inital_state: str = Field(
+    initial_state: str = Field(
         default="zero", description="This is an option to set the initial states of the model to zero."
     )
     lat: float = Field(..., description="Latitude")

--- a/src/icefabric/schemas/modules.py
+++ b/src/icefabric/schemas/modules.py
@@ -428,7 +428,7 @@ class LSTM(BaseModel):
         description="Refer to https://github.com/NOAA-OWP/lstm/blob/master/bmi_config_files/README.md",
     )
     elev_mean: float = Field(..., description="Catchment mean elevation (m) above sea level")
-    inital_state: str = Field(
+    initial_state: str = Field(
         default="zero", description="This is an option to set the initial states of the model to zero."
     )
     lat: float = Field(..., description="Latitude")
@@ -453,7 +453,7 @@ class LSTM(BaseModel):
             f"basin_id: {self.basin_id}",
             f"basin_name: {self.basin_name}",
             f"elev_mean: {self.elev_mean}",
-            f"inital_state: {self.inital_state}",
+            f"initial_state: {self.initial_state}",
             f"lat: {self.lat}",
             f"lon: {self.lon}",
             f"slope_mean: {self.slope_mean}",


### PR DESCRIPTION
### Issue Fixed

Changed a typo from `inital_state` to `initial_state` in the LSTM API

Credit to @jswade-rtx for the find