### PR TITLE
Ngwpc 8509/8510 Add remaining module endpoints/fix any problems with existing endpoints.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,8 @@ from app.routers.nwm_modules.router import (
     topmodel_router,
     topoflow_router,
     troute_router,
+    ueb_router,
+    cfe_router
 )
 from app.routers.ras_xs.router import api_router as ras_api_router
 from app.routers.rise_wrappers.router import api_router as rise_api_wrap_router
@@ -135,6 +137,8 @@ app.include_router(sacsma_router, prefix="/v1")
 app.include_router(troute_router, prefix="/v1")
 app.include_router(topmodel_router, prefix="/v1")
 app.include_router(topoflow_router, prefix="/v1")
+app.include_router(ueb_router, prefix="/v1")
+app.include_router(cfe_router, prefix="/v1")
 app.include_router(ras_api_router, prefix="/v1")
 app.include_router(rise_api_wrap_router, prefix="/v1")
 

--- a/app/routers/nwm_modules/router.py
+++ b/app/routers/nwm_modules/router.py
@@ -5,19 +5,18 @@ from app import get_catalog, get_graphs
 from icefabric.modules import SmpModules, config_mapper
 from icefabric.schemas import HydrofabricDomains
 from icefabric.schemas.modules import (
+    CFE,
     LASAM,
     LSTM,
     SFT,
     SMP,
-    Albedo,
+    UEB,
     NoahOwpModular,
     SacSma,
     Snow17,
     Topmodel,
     Topoflow,
     TRoute,
-    UEB,
-    CFE,
 )
 
 sft_router = APIRouter(prefix="/modules/sft")
@@ -448,6 +447,7 @@ async def get_topoflow_ipes(
     )
 
 
+'''
 @topoflow_router.get("/albedo", tags=["NWM Modules"])
 async def get_albedo(
     landcover_state: Albedo = Query(
@@ -469,6 +469,8 @@ async def get_albedo(
     A float albedo value [0, 1]
     """
     return Albedo.get_landcover_albedo(landcover_state.landcover).value
+'''
+
 
 @ueb_router.get("/", tags=["NWM Modules"])
 async def get_ueb_ipes(
@@ -510,8 +512,9 @@ async def get_ueb_ipes(
         namespace=domain.value,
         identifier=f"gages-{identifier}",
         graph=network_graphs[domain],
-        envca=envca
+        envca=envca,
     )
+
 
 @cfe_router.get("/", tags=["NWM Modules"])
 async def get_cfe_ipes(
@@ -565,7 +568,7 @@ async def get_cfe_ipes(
         namespace=domain.value,
         identifier=f"gages-{identifier}",
         graph=network_graphs[domain],
-        cfe_version = cfe_version,
-        sft_included = sft_included,
-        rootzone_aet = rootzone_aet,
+        cfe_version=cfe_version,
+        sft_included=sft_included,
+        rootzone_aet=rootzone_aet,
     )

--- a/app/routers/nwm_modules/router.py
+++ b/app/routers/nwm_modules/router.py
@@ -16,6 +16,8 @@ from icefabric.schemas.modules import (
     Topmodel,
     Topoflow,
     TRoute,
+    UEB,
+    CFE,
 )
 
 sft_router = APIRouter(prefix="/modules/sft")
@@ -28,6 +30,8 @@ sacsma_router = APIRouter(prefix="/modules/sacsma")
 troute_router = APIRouter(prefix="/modules/troute")
 topmodel_router = APIRouter(prefix="/modules/topmodel")
 topoflow_router = APIRouter(prefix="/modules/topoflow")
+ueb_router = APIRouter(prefix="/modules/ueb")
+cfe_router = APIRouter(prefix="/modules/cfe")
 
 
 @sft_router.get("/", tags=["NWM Modules"])
@@ -158,7 +162,7 @@ async def get_smp_ipes(
         namespace=domain.value,
         identifier=f"gages-{identifier}",
         graph=network_graphs[domain],
-        module=module,
+        extra_module=module,
     )
 
 
@@ -407,7 +411,6 @@ async def get_topmodel_ipes(
     )
 
 
-# TODO - Restore endpoint once the generation of IPEs for TopoFlow is possible/implemented
 @topoflow_router.get("/", tags=["NWM Modules"])
 async def get_topoflow_ipes(
     identifier: str = Query(
@@ -466,3 +469,103 @@ async def get_albedo(
     A float albedo value [0, 1]
     """
     return Albedo.get_landcover_albedo(landcover_state.landcover).value
+
+@ueb_router.get("/", tags=["NWM Modules"])
+async def get_ueb_ipes(
+    identifier: str = Query(
+        ...,
+        description="Gage ID from which to trace upstream catchments.",
+        examples=["01010000"],
+        openapi_examples={"ueb_example": {"summary": "UEB Example", "value": "01010000"}},
+    ),
+    domain: HydrofabricDomains = Query(
+        HydrofabricDomains.CONUS,
+        description="The iceberg namespace used to query the hydrofabric.",
+        openapi_examples={"ueb_example": {"summary": "UEB Example", "value": "conus_hf"}},
+    ),
+    envca: bool = Query(
+        False,
+        description="If source is ENVCA, then set to True. Defaults to False.",
+        openapi_examples={"ueb_example": {"summary": "UEB Example", "value": False}},
+    ),
+    catalog: Catalog = Depends(get_catalog),
+    network_graphs=Depends(get_graphs),
+) -> list[UEB]:
+    """
+    An endpoint to return configurations for UEB.
+
+    This endpoint traces upstream from a given gage ID to get all catchments
+    and returns UEB parameter configurations for each catchment.
+
+    **Parameters:**
+    - **identifier**: The Gage ID from which upstream catchments are traced.
+    - **domain**: The geographic domain used to filter catchments.
+    - **envca**:  Designates that the source is ENVCA.
+
+    **Returns:**
+    A list of UEB pydantic objects for each catchment.
+    """
+    return config_mapper["ueb"](
+        catalog=catalog,
+        namespace=domain.value,
+        identifier=f"gages-{identifier}",
+        graph=network_graphs[domain],
+        envca=envca
+    )
+
+@cfe_router.get("/", tags=["NWM Modules"])
+async def get_cfe_ipes(
+    identifier: str = Query(
+        ...,
+        description="Gage ID from which to trace upstream catchments.",
+        examples=["01010000"],
+        openapi_examples={"cfe_example": {"summary": "CFE Example", "value": "01010000"}},
+    ),
+    domain: HydrofabricDomains = Query(
+        HydrofabricDomains.CONUS,
+        description="The iceberg namespace used to query the hydrofabric.",
+        openapi_examples={"cfe_example": {"summary": "CFE Example", "value": "conus_hf"}},
+    ),
+    cfe_version: str = Query(
+        ...,
+        description="Select which version of CFE to use: CFE-S or CFE-X.",
+        openapi_examples={"cfe_example": {"summary": "CFE Example", "value": "CFE-S"}},
+    ),
+    sft_included: bool = Query(
+        False,
+        description="True if SFT is in the 'dep_modules_included' definition as declared in HF API repo.",
+        openapi_examples={"cfe_example": {"summary": "CFE Example", "value": False}},
+    ),
+    rootzone_aet: bool = Query(
+        False,
+        description="Turn on rootzone AET",
+        openapi_examples={"cfe_example": {"summary": "CFE Example", "value": False}},
+    ),
+    catalog: Catalog = Depends(get_catalog),
+    network_graphs=Depends(get_graphs),
+) -> list[CFE]:
+    """
+    An endpoint to return configurations for CFE.
+
+    This endpoint traces upstream from a given gage ID to get all catchments
+    and returns CFE parameter configurations for each catchment.
+
+    **Parameters:**
+    - **identifier**: The Gage ID from which upstream catchments are traced.
+    - **domain**: The geographic domain used to filter catchments.
+    - **cfe_version**:  Select which version of CFE to use: CFE-S or CFE-X.
+    - **sft_included**: True if SFT is in the 'dep_modules_included' definition as declared in HF API repo.
+    - **rootzone_aet**: Turn on rootzone AET if True.
+
+    **Returns:**
+    A list of CFE pydantic objects for each catchment.
+    """
+    return config_mapper["cfe"](
+        catalog=catalog,
+        namespace=domain.value,
+        identifier=f"gages-{identifier}",
+        graph=network_graphs[domain],
+        cfe_version = cfe_version,
+        sft_included = sft_included,
+        rootzone_aet = rootzone_aet,
+    )

--- a/src/icefabric/modules/create_ipes.py
+++ b/src/icefabric/modules/create_ipes.py
@@ -173,10 +173,10 @@ def get_snow17_parameters(
     crs = gauge["divides"].crs
     transformer = Transformer.from_crs(crs, 4326)
     wgs84_latlon = transformer.transform(result_df["lon"], result_df["lat"])
-    result_df["lon"] = wgs84_latlon[0]
-    result_df["lat"] = wgs84_latlon[1]
+    result_df["lat"] = wgs84_latlon[0]
+    result_df["lon"] = wgs84_latlon[1]
 
-    # Default parameter values used only for CONUS
+    # Default parameter values used for oCONUS or if data is missing.
     result_df["mfmax"] = CalibratableScheme.MFMAX.value
     result_df["mfmin"] = CalibratableScheme.MFMIN.value
     result_df["uadj"] = CalibratableScheme.UADJ.value
@@ -259,13 +259,13 @@ def get_smp_parameters(
     result_df = df.select(expressions)
 
     # Initializing parameters dependent to unique modules
-    soil_storage_model = "NA"
-    soil_storage_depth = "NA"
-    water_table_based_method = "NA"
-    soil_moisture_profile_option = "NA"
-    soil_depth_layers = "NA"
-    water_depth_layers = "NA"
-    water_table_depth = "NA"
+    soil_storage_model = None
+    soil_storage_depth = None
+    water_table_based_method = None
+    soil_moisture_profile_option = None
+    soil_depth_layers = None
+    water_depth_layers = None
+    water_table_depth = None
 
     if extra_module:
         if extra_module == "CFE-S" or extra_module == "CFE-X":
@@ -365,8 +365,8 @@ def get_lstm_parameters(catalog: Catalog, namespace: str, identifier: str, graph
     crs = gauge["divides"].crs
     transformer = Transformer.from_crs(crs, 4326)
     wgs84_latlon = transformer.transform(result_df["lon"], result_df["lat"])
-    result_df["lon"] = wgs84_latlon[0]
-    result_df["lat"] = wgs84_latlon[1]
+    result_df["lat"] = wgs84_latlon[0]
+    result_df["lon"] = wgs84_latlon[1]
 
     pydantic_models = []
     for _, row_dict in result_df.iterrows():
@@ -880,7 +880,7 @@ def get_ueb_parameters(
     result_df["lon"] = wgs84_latlon[0]
     result_df["lat"] = wgs84_latlon[1]
 
-    # Default parameter values used only for CONUS
+    # Default parameter values
     result_df["jan_temp_range"] = UEBValues.JAN_TEMP.value
     result_df["feb_temp_range"] = UEBValues.FEB_TEMP.value
     result_df["mar_temp_range"] = UEBValues.MAR_TEMP.value
@@ -955,6 +955,7 @@ def get_cfe_parameters(
     cfe_version: str,
     graph: rx.PyDiGraph,
     sft_included: bool = False,
+    rootzone_aet: bool = False,
 ) -> list[CFE]:
     """Creates the initial parameter estimates for the CFE module
 
@@ -971,6 +972,8 @@ def get_cfe_parameters(
         to use Shaake or Xinanjiang for surface partitioning.
     sft_included: bool
         True if SFT is in the "dep_modules_included" definition as declared in HF API repo.
+    rootzone_aet: bool
+        Turn on rootzone based AET (actual evapotranspiration)
 
     Returns
     -------
@@ -995,30 +998,51 @@ def get_cfe_parameters(
     conus_param_df = params_df.filter(pl.col("divide_id").is_in(divides_list)).collect().to_pandas()
     df = pd.merge(conus_param_df, df, on="divide_id", how="left")
 
+    if rootzone_aet:
+        is_aet_rootzone = True
+        soil_layer_depths = CFEValues.SOIL_LAYER_DEPTHS.value
+        max_rootzone_layer = CFEValues.MAX_ROOTZONE_LAYER.value
+    else:
+        is_aet_rootzone = False
+        soil_layer_depths = None
+        max_rootzone_layer = None
+
     if cfe_version == "CFE-X":
         surface_partitioning_scheme = CFEValues.XINANJIANG.value
         urban_decimal_fraction = CFEValues.URBAN_FRACT.value
-        is_sft_coupled = "NA"
+        ice_content_thresh = None
+        if sft_included:
+            is_sft_coupled = True
+        else:
+            is_sft_coupled = False
     elif cfe_version == "CFE-S":
         surface_partitioning_scheme = CFEValues.SCHAAKE.value
-        a_Xinanjiang_inflection_point_parameter = "NA"
-        b_Xinanjiang_shape_parameter = "NA"
-        x_Xinanjiang_shape_parameter = "NA"
-        urban_decimal_fraction = "NA"
+        urban_decimal_fraction = None
+        a_Xinanjiang_inflection_point_parameter = None
+        b_Xinanjiang_shape_parameter = None
+        x_Xinanjiang_shape_parameter = None
         if sft_included:
-            is_sft_coupled = 1
+            is_sft_coupled = True
+            ice_content_thresh = CFEValues.ICE_CONTENT_THR.value
         else:
-            is_sft_coupled = 0
+            is_sft_coupled = False
+            ice_content_thresh = None
     else:
         raise ValueError(f"Passing unsupported cfe_version into endpoint: {cfe_version}")
 
     pydantic_models = []
     for _, row_dict in df.iterrows():
         # Instantiate the Pydantic model for each row
+        if cfe_version == "CFE-X":
+            a_Xinanjiang_inflection_point_parameter=(row_dict["a_Xinanjiang_inflection_point_parameter"])
+            b_Xinanjiang_shape_parameter=(row_dict["b_Xinanjiang_shape_parameter"])
+            x_Xinanjiang_shape_parameter=(row_dict["x_Xinanjiang_shape_parameter"])
+            urban_decimal_fraction=row_dict["mean.impervious"]
         model_instance = CFE(
             catchment=row_dict["divide_id"],
             surface_partitioning_scheme=surface_partitioning_scheme,
             is_sft_coupled=str(is_sft_coupled),
+            ice_content_thresh = ice_content_thresh,
             soil_params_b=row_dict["mode.bexp_soil_layers_stag=1"],
             soil_params_satdk=row_dict["geom_mean.dksat_soil_layers_stag=1"],
             soil_params_satpsi=row_dict["geom_mean.psisat_soil_layers_stag=1"],
@@ -1028,17 +1052,14 @@ def get_cfe_parameters(
             max_gw_storage=row_dict["mean.Zmax"],
             Cgw=row_dict["mean.Coeff"],
             expon=row_dict["mode.Expon"],
-            a_Xinanjiang_inflection_point_parameter=str(row_dict["a_Xinanjiang_inflection_point_parameter"])
-            if cfe_version == "CFE-X"
-            else a_Xinanjiang_inflection_point_parameter,
-            b_Xinanjiang_shape_parameter=str(row_dict["b_Xinanjiang_shape_parameter"])
-            if cfe_version == "CFE-X"
-            else b_Xinanjiang_shape_parameter,
-            x_Xinanjiang_shape_parameter=str(row_dict["x_Xinanjiang_shape_parameter"])
-            if cfe_version == "CFE-X"
-            else x_Xinanjiang_shape_parameter,
-            urban_decimal_fraction=str(urban_decimal_fraction),
+            a_Xinanjiang_inflection_point_parameter=a_Xinanjiang_inflection_point_parameter,
+            b_Xinanjiang_shape_parameter=b_Xinanjiang_shape_parameter,
+            x_Xinanjiang_shape_parameter=x_Xinanjiang_shape_parameter,
+            urban_decimal_fraction=urban_decimal_fraction,
             refkdt=row_dict["mean.refkdt"],
+            is_aet_rootzone=is_aet_rootzone,
+            soil_layer_depths=soil_layer_depths,
+            max_rootzone_layer=max_rootzone_layer,
         )
         pydantic_models.append(model_instance)
     return pydantic_models

--- a/src/icefabric/schemas/modules.py
+++ b/src/icefabric/schemas/modules.py
@@ -2,7 +2,7 @@
 
 import enum
 from pathlib import Path
-from typing import Literal, Protocol, Optional
+from typing import Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -19,7 +19,7 @@ class NWMProtocol(Protocol):
         ...
 
 
-class IceFractionScheme(str, enum.Enum):
+class IceFractionScheme(enum.Enum):
     """The ice fraction scheme to be used in SFT"""
 
     SCHAAKE = "Schaake"
@@ -114,7 +114,7 @@ class Albedo(BaseModel):
         return getattr(AlbedoValues, v)
 
 
-class CalibratableScheme(str, enum.Enum):
+class CalibratableScheme(enum.Enum):
     """The calibratable values to be used in Snow17"""
 
     MFMAX = 1.00
@@ -205,7 +205,7 @@ class Snow17(BaseModel):
         return snow17_bmi_file
 
 
-class SoilScheme(str, enum.Enum):
+class SoilScheme(enum.Enum):
     """The calibratable scheme to be used in SMP"""
 
     CFE_SOIL_STORAGE = "conceptual"
@@ -230,29 +230,29 @@ class SMP(BaseModel):
     soil_moisture_fraction_depth: float = Field(
         default=0.4, description="Soil moisture fraction depth in meters"
     )
-    soil_storage_model: Optional[str] = Field(
+    soil_storage_model: str | None = Field(
         ...,
         description="If conceptual, conceptual models are used for computing the soil moisture profile (e.g., CFE). If layered, layered-based soil moisture models are used (e.g., LGAR). If topmodel, topmodel's variables are used",
     )
 
-    soil_storage_depth: Optional[float] = Field(
+    soil_storage_depth: float | None = Field(
         ...,
         description="Depth of the soil reservoir model (e.g., CFE). Note: this depth can be different from the depth of the soil moisture profile which is based on soil_z",
     )
 
-    water_table_based_method: Optional[str] = Field(
-    ...,
-    description="Needed if soil_storage_model = topmodel. flux-based uses an iterative scheme, and deficit-based uses catchment deficit to compute soil moisture profile",
+    water_table_based_method: str | None = Field(
+        ...,
+        description="Needed if soil_storage_model = topmodel. flux-based uses an iterative scheme, and deficit-based uses catchment deficit to compute soil moisture profile",
     )
 
-    soil_moisture_profile_option: Optional[str] = Field(
+    soil_moisture_profile_option: str | None = Field(
         ...,
         description="Constant for layered-constant profile. linear for linearly interpolated values between two consecutive layers. Needed if soil_storage_model = layered",
     )
-    soil_depth_layers: Optional[float] = Field(
+    soil_depth_layers: float | None = Field(
         ..., description="Absolute depth of soil layers. Needed if soil_storage_model = layered"
     )
-    water_table_depth: Optional[float] = Field(default="NA", description="N/A")
+    water_table_depth: float | None = Field(default="NA", description="N/A")
 
     def to_bmi_config(self) -> list[str]:
         """Convert the model back to the original config file format"""
@@ -286,7 +286,7 @@ class SMP(BaseModel):
         return smp_bmi_file
 
 
-class SacSmaValues(str, enum.Enum):
+class SacSmaValues(enum.Enum):
     """The values to be used in SAC SMA"""
 
     UZTWM = 75.0
@@ -660,8 +660,6 @@ class TRoute(BaseModel):
         "flowpath_columns": ["id", "toid", "lengthkm"],
         "attributes_columns": [
             "attributes_id",
-            "rl_gages",
-            "rl_NHDWaterbodyComID",
             "MusK",
             "MusX",
             "n",
@@ -697,8 +695,6 @@ class TRoute(BaseModel):
         "ncc": "nCC",
         "s0": "So",
         "bw": "BtmWdth",
-        "waterbody": "rl_NHDWaterbodyComID",
-        "gages": "rl_gages",
         "tw": "TopWdth",
         "twcc": "TopWdthCC",
         "musk": "MusK",
@@ -810,7 +806,7 @@ class TRoute(BaseModel):
         },
     }
 
-    output_param = {
+    output_parameters = {
         "stream_output": {
             "stream_output_directory": ".",
             "stream_output_time": divmod(5 * 300, 3600)[0] + 1,
@@ -827,7 +823,7 @@ class TRoute(BaseModel):
     comp_param: dict = Field(default=comp_param, description="Compute Parameters")
     res_da: dict = Field(default=res_da, description="Res DA parameters for computation")
     stream_da: dict = Field(default=stream_da, description="Stream parameters for computation")
-    output_param: dict = Field(default=output_param, description="Output Parameters")
+    output_parameters: dict = Field(default=output_parameters, description="Output Parameters")
     ntwk_columns: dict = Field(default=ntwk_columns, description="A network topology set of parameters")
     dupseg: list[str] = Field(default=dupseg, description="A network topology set of parameters")
 
@@ -838,7 +834,7 @@ class TRoute(BaseModel):
             f"log_parameters: {self.log_param}",
             f"network_topology_parameters: {self.nwtopo_param}",
             f"compute_parameters: {self.comp_param}",
-            f"output_param: {self.output_param}",
+            f"output_parameters: {self.output_parameters}",
         }
 
     def model_dump_config(self, output_path: Path) -> Path:
@@ -939,7 +935,7 @@ class Topmodel(BaseModel):
         return topmodel_bmi_file
 
 
-class TopoFlowValues(float, enum.Enum):
+class TopoFlowValues(enum.Enum):
     """Default parameter values for Topoflow"""
 
     H_ACTIVE_LAYER = 0.125
@@ -1026,7 +1022,7 @@ class Topoflow(BaseModel):
         return topoflow_bmi_file
 
 
-class UEBValues(str, enum.Enum):
+class UEBValues(enum.Enum):
     """The calibratable values to be used in UEB"""
 
     JAN_TEMP = 11.04395
@@ -1058,7 +1054,6 @@ class UEBValues(str, enum.Enum):
     TS_LAST = -9999
 
 
-
 class UEB(BaseModel):
     """Pydantic model for UEB module configuration"""
 
@@ -1083,20 +1078,39 @@ class UEB(BaseModel):
     nov_temp_range: float = Field(default=UEBValues.NOV_TEMP.value, description="Average temperature")
     dec_temp_range: float = Field(default=UEBValues.DEC_TEMP.value, description="Average temperature")
     Usic: float = Field(default=UEBValues.USIC.value, description="Energy content initial condition (kg m-3)")
-    Wsis: float = Field(default=UEBValues.WSIS.value, description="Snow water equivalent initial condition (m)")
-    Tic: float = Field(default=UEBValues.TIC.value, description="Snow surface dimensionless age initial condition")
-    Wcic: float = Field(default=UEBValues.WCIC.value, description="Snow water equivalent of canopy condition(m)")
+    Wsis: float = Field(
+        default=UEBValues.WSIS.value, description="Snow water equivalent initial condition (m)"
+    )
+    Tic: float = Field(
+        default=UEBValues.TIC.value, description="Snow surface dimensionless age initial condition"
+    )
+    Wcic: float = Field(
+        default=UEBValues.WCIC.value, description="Snow water equivalent of canopy condition(m)"
+    )
     df: float = Field(default=UEBValues.DF.value, description="Drift factor multiplier")
     Aep: float = Field(default=UEBValues.AEP.value, description="Albedo extinction coefficient")
     cc: float = Field(default=UEBValues.CC.value, description="Canopy coverage fraction")
     hcan: float = Field(default=UEBValues.HCAN.value, description="Canopy height")
     lai: float = Field(default=UEBValues.LAI.value, description="Leaf area index")
-    Sbar: float = Field(default=UEBValues.SBAR.value, description="Maximum snow load held per unit branch area")
-    ycage: float = Field(default=UEBValues.YCAGE.value, description="Forest age flag for wind speed profile parameterization")
-    subalb: int = Field(default=UEBValues.SUBALB.value, description="Albedo (fraction 0-1) of the substrate beneath the snow (ground, or glacier)")
-    subtype: float = Field(default=UEBValues.SUBTYPE.value, description="Type of beneath snow substrate encoded as (0 = Ground/Non Glacier, 1=Clean" \
-                                                                        " Ice/glacier, 2= Debris covered ice/glacier, 3= Glacier snow accumulation zone")
-    gsurf: float = Field(default=UEBValues.GSURF.value, description="The fraction of surface melt that runs off (e.g. from a glacier")
+    Sbar: float = Field(
+        default=UEBValues.SBAR.value, description="Maximum snow load held per unit branch area"
+    )
+    ycage: float = Field(
+        default=UEBValues.YCAGE.value, description="Forest age flag for wind speed profile parameterization"
+    )
+    subalb: float = Field(
+        default=UEBValues.SUBALB.value,
+        description="Albedo (fraction 0-1) of the substrate beneath the snow (ground, or glacier)",
+    )
+    subtype: float = Field(
+        default=UEBValues.SUBTYPE.value,
+        description="Type of beneath snow substrate encoded as (0 = Ground/Non Glacier, 1=Clean"
+        " Ice/glacier, 2= Debris covered ice/glacier, 3= Glacier snow accumulation zone",
+    )
+    gsurf: float = Field(
+        default=UEBValues.GSURF.value,
+        description="The fraction of surface melt that runs off (e.g. from a glacier",
+    )
     ts_last: float = Field(default=UEBValues.TS_LAST.value, description="Average temperature")
 
     def to_bmi_config(self) -> list[str]:
@@ -1192,7 +1206,7 @@ class CFE(BaseModel):
         False,
         description="Optional. Turns on/off the CFE coupling with the SoilFreezeThaw. If this parameter is defined to be True (or 1) in the config file and surface_partitioning_scheme=Schaake, then ice_content_threshold also needs to be defined in the config file.",
     )
-    ice_content_thresh: Optional[float] = Field(
+    ice_content_thresh: float | None = Field(
         default=CFEValues.ICE_CONTENT_THR.value,
         description="Optional. This represents the ice content above which soil is impermeable. If this is_sft_couple is defined to be True (or 1) in the config file and surface_partitioning_scheme=Schaake, then this also needs to be defined in the config file.",
     )
@@ -1257,27 +1271,34 @@ class CFE(BaseModel):
         default=CFEValues.GIUH.value,
         description="Giuh (geomorphological instantaneous unit hydrograph) ordinates in dt time steps",
     )
-    a_Xinanjiang_inflection_point_parameter: Optional[float] = Field(
+    a_Xinanjiang_inflection_point_parameter: float | None = Field(
         ...,
         description="When surface_water_partitioning_scheme=Xinanjiang",
     )
-    b_Xinanjiang_shape_parameter: Optional[float] = Field(
+    b_Xinanjiang_shape_parameter: float | None = Field(
         ...,
         description="When surface_water_partitioning_scheme=Xinanjiang",
     )
-    x_Xinanjiang_shape_parameter: Optional[float] = Field(
+    x_Xinanjiang_shape_parameter: float | None = Field(
         ...,
         description="When surface_water_partitioning_scheme=Xinanjiang",
     )
-    urban_decimal_fraction: Optional[float] = Field(..., description="When surface_water_partitioning_scheme=Xinanjiang")
+    urban_decimal_fraction: float | None = Field(
+        ..., description="When surface_water_partitioning_scheme=Xinanjiang"
+    )
     refkdt: float = Field(
         default=CFEValues.REFKDT.value,
         description="Reference Soil Infiltration Parameter (used in runoff formulation)",
     )
     soil_params_depth: float = Field(default=CFEValues.SOIL_DEPTH.value, description="Soil depth")
     is_aet_rootzone: bool = Field(default=CFEValues.IS_AET.value, description="Turn on rootzone AET")
-    soil_layer_depths: Optional[list[float]] = Field(default=CFEValues.SOIL_LAYER_DEPTHS.value, description="array of depths from the surface for AET")
-    max_rootzone_layer: Optional[float] = Field(default=CFEValues.MAX_ROOTZONE_LAYER.value, description="layer of the soil that is the maximum root zone depth")
+    soil_layer_depths: list[float] | None = Field(
+        default=CFEValues.SOIL_LAYER_DEPTHS.value, description="array of depths from the surface for AET"
+    )
+    max_rootzone_layer: float | None = Field(
+        default=CFEValues.MAX_ROOTZONE_LAYER.value,
+        description="layer of the soil that is the maximum root zone depth",
+    )
 
     def to_bmi_config(self) -> list[str]:
         """Convert the model back to the original config file format"""

--- a/src/icefabric/schemas/modules.py
+++ b/src/icefabric/schemas/modules.py
@@ -2,9 +2,9 @@
 
 import enum
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import Literal, Protocol, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class NWMProtocol(Protocol):
@@ -31,10 +31,7 @@ class SFT(BaseModel):
 
     model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
     catchment: str = Field(..., description="The catchment ID")
-    verbosity: str = Field(default="none", description="Verbosity level")
     soil_moisture_bmi: int = Field(default=1, description="Soil moisture BMI parameter")
-    end_time: str = Field(default="1.[d]", description="End time with units")
-    dt: str = Field(default="1.0[h]", description="Time step with units")
     soil_params_smcmax: float = Field(..., description="Maximum soil moisture content", alias="smcmax")
     soil_params_b: float = Field(..., description="Soil moisture retention curve parameter (bexp)", alias="b")
     soil_params_satpsi: float = Field(..., description="Saturated soil suction (psisat)", alias="satpsi")
@@ -59,10 +56,7 @@ class SFT(BaseModel):
         z_values = ",".join([str(z) for z in self.soil_z])
 
         return [
-            f"verbosity={self.verbosity}",
             f"soil_moisture_bmi={self.soil_moisture_bmi}",
-            f"end_time={self.end_time}",
-            f"dt={self.dt}",
             f"soil_params.smcmax={self.soil_params_smcmax}",
             f"soil_params.b={self.soil_params_b}",
             f"soil_params.satpsi={self.soil_params_satpsi}",
@@ -215,13 +209,13 @@ class SoilScheme(str, enum.Enum):
     """The calibratable scheme to be used in SMP"""
 
     CFE_SOIL_STORAGE = "conceptual"
-    CFE_STORAGE_DEPTH = "2.0"
+    CFE_STORAGE_DEPTH = 2.0
     TOPMODEL_SOIL_STORAGE = "TopModel"
     TOPMODEL_WATER_TABLE_METHOD = "flux-based"
     LASAM_SOIL_STORAGE = "layered"
     LASAM_SOIL_MOISTURE = "constant"
-    LASAM_SOIL_DEPTH_LAYERS = "2.0"
-    LASAM_WATER_TABLE_DEPTH = "10[m]"
+    LASAM_SOIL_DEPTH_LAYERS = 2.0
+    LASAM_WATER_TABLE_DEPTH = 10.0
 
 
 class SMP(BaseModel):
@@ -229,7 +223,6 @@ class SMP(BaseModel):
 
     model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
     catchment: str = Field(..., description="The catchment ID")
-    verbosity: str = Field(default="none", description="Verbosity level")
     soil_params_smcmax: float = Field(..., description="Maximum soil moisture content", alias="smcmax")
     soil_params_b: float = Field(..., description="Soil moisture retention curve parameter (bexp)", alias="b")
     soil_params_satpsi: float = Field(..., description="Saturated soil suction (psisat)", alias="satpsi")
@@ -237,33 +230,35 @@ class SMP(BaseModel):
     soil_moisture_fraction_depth: float = Field(
         default=0.4, description="Soil moisture fraction depth in meters"
     )
-    soil_storage_model: str = Field(
-        default="NA",
+    soil_storage_model: Optional[str] = Field(
+        ...,
         description="If conceptual, conceptual models are used for computing the soil moisture profile (e.g., CFE). If layered, layered-based soil moisture models are used (e.g., LGAR). If topmodel, topmodel's variables are used",
     )
-    soil_storage_depth: str = Field(
-        default="none",
+
+    soil_storage_depth: Optional[float] = Field(
+        ...,
         description="Depth of the soil reservoir model (e.g., CFE). Note: this depth can be different from the depth of the soil moisture profile which is based on soil_z",
     )
-    water_table_based_method: str = Field(
-        default="NA",
-        description="Needed if soil_storage_model = topmodel. flux-based uses an iterative scheme, and deficit-based uses catchment deficit to compute soil moisture profile",
+
+    water_table_based_method: Optional[str] = Field(
+    ...,
+    description="Needed if soil_storage_model = topmodel. flux-based uses an iterative scheme, and deficit-based uses catchment deficit to compute soil moisture profile",
     )
-    soil_moisture_profile_option: str = Field(
-        default="NA",
+
+    soil_moisture_profile_option: Optional[str] = Field(
+        ...,
         description="Constant for layered-constant profile. linear for linearly interpolated values between two consecutive layers. Needed if soil_storage_model = layered",
     )
-    soil_depth_layers: str = Field(
-        default="NA", description="Absolute depth of soil layers. Needed if soil_storage_model = layered"
+    soil_depth_layers: Optional[float] = Field(
+        ..., description="Absolute depth of soil layers. Needed if soil_storage_model = layered"
     )
-    water_table_depth: str = Field(default="NA", description="N/A")
+    water_table_depth: Optional[float] = Field(default="NA", description="N/A")
 
     def to_bmi_config(self) -> list[str]:
         """Convert the model back to the original config file format"""
         z_values = ",".join([str(z) for z in self.soil_z])
 
         return [
-            f"verbosity={self.verbosity}",
             f"soil_params.smcmax={self.soil_params_smcmax}",
             f"soil_params.b={self.soil_params_b}",
             f"soil_params.satpsi={self.soil_params_satpsi}",
@@ -423,10 +418,6 @@ class LSTM(BaseModel):
     basin_id: str = Field(
         ..., description="Refer to https://github.com/NOAA-OWP/lstm/blob/master/bmi_config_files/README.md"
     )
-    basin_name: str = Field(
-        default="",
-        description="Refer to https://github.com/NOAA-OWP/lstm/blob/master/bmi_config_files/README.md",
-    )
     elev_mean: float = Field(..., description="Catchment mean elevation (m) above sea level")
     initial_state: str = Field(
         default="zero", description="This is an option to set the initial states of the model to zero."
@@ -434,32 +425,17 @@ class LSTM(BaseModel):
     lat: float = Field(..., description="Latitude")
     lon: float = Field(..., description="Longitude")
     slope_mean: float = Field(..., description="Catchment mean slope (m km−1)")
-    timestep: str = Field(
-        default="1 hour",
-        description="Refer to https://github.com/NOAA-OWP/lstm/blob/master/bmi_config_files/README.md",
-    )
-    train_cfg_file: str = Field(
-        default="",
-        description="This is a configuration file used when training the model. It has critical information on the LSTM architecture and should not be altered.",
-    )
-    verbose: str = Field(
-        default="0", description="Change to 1 in order to print additional BMI information during runtime."
-    )
 
     def to_bmi_config(self) -> list[str]:
         """Convert the model back to the original config file format"""
         return [
             f"area_sqkm: {self.area_sqkm}",
             f"basin_id: {self.basin_id}",
-            f"basin_name: {self.basin_name}",
             f"elev_mean: {self.elev_mean}",
             f"initial_state: {self.initial_state}",
             f"lat: {self.lat}",
             f"lon: {self.lon}",
             f"slope_mean: {self.slope_mean}",
-            f"timestep: {self.timestep}",
-            f"train_cfg_file: {self.train_cfg_file}",
-            f"verbose: {self.verbose}",
         ]
 
     def model_dump_config(self, output_path: Path) -> Path:
@@ -487,12 +463,8 @@ class LASAM(BaseModel):
 
     model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
     catchment: str = Field(..., description="The catchment ID")
-    verbosity: str = Field(default="none", description="NA")
-    soil_params_file: str = Field(..., description="Full path to vG_default_params.dat")
     layer_thickness: str = Field(default="200.0[cm]", description="Thickness of each layer (array)")
     initial_psi: str = Field(default="2000.0[cm]", description="NA")
-    timestep: str = Field(default="300[sec]", description="NA")
-    endtime: str = Field(default="1000[hr]", description="NA")
     forcing_resolution: str = Field(default="3600[sec]", description="NA")
     ponded_depth_max: str = Field(
         default="1.1[cm]",
@@ -520,12 +492,8 @@ class LASAM(BaseModel):
         giuh_ordinates = ",".join([str(giuh) for giuh in self.giuh_ordinates])
 
         return [
-            f"verbosity={self.verbosity}",
-            f"soil_params_file={self.soil_params_file}",
             f"layer_thickness={self.layer_thickness}",
             f"initial_psi={self.initial_psi}",
-            f"timestep={self.timestep}",
-            f"endtime={self.endtime}",
             f"forcing_resolution={self.forcing_resolution}",
             f"ponded_depth_max={self.ponded_depth_max}",
             f"use_closed_form_G={self.use_closed_form_G}",
@@ -565,12 +533,6 @@ class NoahOwpModular(BaseModel):
 
     model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
     catchment: str = Field(..., description="The catchment ID")
-    dt: float = Field(default=3600.0, description="Timestep [seconds]")
-    startdate: str = Field(default="202408260000", description="UTC time start of simulation (YYYYMMDDhhmm)")
-    enddate: str = Field(default="202408260000", description="# UTC time end of simulation (YYYYMMDDhhmm)")
-    forcing_filename: str = Field(default=".", description="File containing forcing data")
-    output_filename: str = Field(default=".", description="NA")
-    parameter_dir: str = Field(default="test", description="NA")
     general_table: str = Field(default="GENPARM.TBL", description="General param tables and misc params")
     soil_table: str = Field(default="SOILPARM.TBL", description="Soil param table")
     noahowp_table: str = Field(default="MPTABLE.TBL", description="Model param tables (includes veg)")
@@ -627,12 +589,6 @@ class NoahOwpModular(BaseModel):
         sh2o = ",".join([str(h2o) for h2o in self.sh2o])
 
         return [
-            f"dt={self.dt} [s]",
-            f"startdate={self.startdate}",
-            f"enddate={self.enddate}",
-            f"forcing_filename={self.forcing_filename}",
-            f"output_filename={self.output_filename}",
-            f"parameter_dir={self.parameter_dir}",
             f"general_table={self.general_table}",
             f"soil_table={self.soil_table}",
             f"noahowp_table={self.noahowp_table}",
@@ -913,7 +869,6 @@ class Topmodel(BaseModel):
     divide_id: str = Field(..., description="The catchment ID")
     num_sub_catchments: int = Field(default=1, description="Number of sub catchments")
     imap: int = Field(default=1, description="NA")
-    yes_print_output: int = Field(default=1, description="NA")
     twi: list[dict] = Field(default=[{"twi": "dist_4.twi"}], description="NA")
     num_topodex_values: int = Field(..., description="NA")
     area: int = Field(default=1, description="NA")
@@ -945,7 +900,6 @@ class Topmodel(BaseModel):
             f"divide_id={self.divide_id}",
             f"num_sub_catchments={self.num_sub_catchments}",
             f"imap={self.imap}",
-            f"yes_print_output={self.yes_print_output}",
             f"twi={self.twi}",
             f"num_topodex_values={self.num_topodex_values}area={self.area}",
             f"num_channels={self.num_channels}",
@@ -1001,10 +955,6 @@ class Topoflow(BaseModel):
 
     model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
     site_prefix: str = Field(..., description="The catchment ID")
-    forcing_file: str = Field(..., description="forcing file name")
-    dt: int = Field(default=1, description="timestep")
-    start_time: str = Field(default="2013032000", description="start time")
-    end_time: str = Field(default="2013052000", description="end time")
     da: float = Field(..., description="drainage area")
     slope: float = Field(..., description="terrain slope in degrees")
     aspect: float = Field(..., description="terrain aspect in degrees")
@@ -1041,10 +991,6 @@ class Topoflow(BaseModel):
         """Convert the model back to the original config file format"""
         return [
             f"site_prefix={self.site_prefix}",
-            f"forcing_file={self.forcing_file}"
-            f"dt={self.dt}"
-            f"starttime={self.start_time}"
-            f"endtime={self.end_time}"
             f"da={self.da}",
             f"slope={self.slope}",
             f"aspect={self.aspect}",
@@ -1095,6 +1041,22 @@ class UEBValues(str, enum.Enum):
     OCT_TEMP = 13.44001
     NOV_TEMP = 11.90162
     DEC_TEMP = 10.71597
+    USIC = 0.0
+    WSIS = 0.0
+    TIC = 0.0
+    WCIC = 0.0
+    DF = 1.0
+    AEP = 0.1
+    CC = 0.4
+    HCAN = 5.0
+    LAI = 2
+    SBAR = 6.6
+    YCAGE = 2.5
+    SUBALB = 0.25
+    SUBTYPE = 0
+    GSURF = 0.0
+    TS_LAST = -9999
+
 
 
 class UEB(BaseModel):
@@ -1120,6 +1082,22 @@ class UEB(BaseModel):
     oct_temp_range: float = Field(default=UEBValues.OCT_TEMP.value, description="Average temperature")
     nov_temp_range: float = Field(default=UEBValues.NOV_TEMP.value, description="Average temperature")
     dec_temp_range: float = Field(default=UEBValues.DEC_TEMP.value, description="Average temperature")
+    Usic: float = Field(default=UEBValues.USIC.value, description="Energy content initial condition (kg m-3)")
+    Wsis: float = Field(default=UEBValues.WSIS.value, description="Snow water equivalent initial condition (m)")
+    Tic: float = Field(default=UEBValues.TIC.value, description="Snow surface dimensionless age initial condition")
+    Wcic: float = Field(default=UEBValues.WCIC.value, description="Snow water equivalent of canopy condition(m)")
+    df: float = Field(default=UEBValues.DF.value, description="Drift factor multiplier")
+    Aep: float = Field(default=UEBValues.AEP.value, description="Albedo extinction coefficient")
+    cc: float = Field(default=UEBValues.CC.value, description="Canopy coverage fraction")
+    hcan: float = Field(default=UEBValues.HCAN.value, description="Canopy height")
+    lai: float = Field(default=UEBValues.LAI.value, description="Leaf area index")
+    Sbar: float = Field(default=UEBValues.SBAR.value, description="Maximum snow load held per unit branch area")
+    ycage: float = Field(default=UEBValues.YCAGE.value, description="Forest age flag for wind speed profile parameterization")
+    subalb: int = Field(default=UEBValues.SUBALB.value, description="Albedo (fraction 0-1) of the substrate beneath the snow (ground, or glacier)")
+    subtype: float = Field(default=UEBValues.SUBTYPE.value, description="Type of beneath snow substrate encoded as (0 = Ground/Non Glacier, 1=Clean" \
+                                                                        " Ice/glacier, 2= Debris covered ice/glacier, 3= Glacier snow accumulation zone")
+    gsurf: float = Field(default=UEBValues.GSURF.value, description="The fraction of surface melt that runs off (e.g. from a glacier")
+    ts_last: float = Field(default=UEBValues.TS_LAST.value, description="Average temperature")
 
     def to_bmi_config(self) -> list[str]:
         """Convert the model back to the original config file format"""
@@ -1164,22 +1142,18 @@ class UEB(BaseModel):
         return ueb_bmi_file
 
 
-class CFEValues(str, enum.Enum):
-    """The default values & schemes to be used in UEB"""
+class CFEValues(enum.Enum):
+    """The default values & schemes to be used in CFE"""
 
-    FORCINGFILE = "BMI"
-    VERBOSITY = 1
     SRFC_RUNOFF_SCHEME = "GIUH"
-    DEBUG = 0
-    NUM_TIMESTEPS = 1
     ICE_CONTENT_THR = 0.15
     SCHAAKE = "Schaake"
     XINANJIANG = "Xinanjiang"
     A_XINANJIANG_INFLECT = -0.2
     B_XINANJIANG_SHAPE = 0.66
     X_XINANJIANG_SHAPE = 0.02
-    SOIL_EXPON = 1
-    SOIL_EXPON_SECONDARY = 1
+    SOIL_EXPON = 1.0
+    SOIL_EXPON_SECONDARY = 1.0
     MAX_GIUH_STORAGE = 0.05
     GW_STORAGE = 0.05
     ALPHA_FC = 0.33
@@ -1189,7 +1163,7 @@ class CFEValues(str, enum.Enum):
     NASH_STORAGE = [0.0, 0.0]
     GIUH = [0.55, 0.25, 0.2]
     URBAN_FRACT = 0.01
-    SOIL_DEPTH = 2
+    SOIL_DEPTH = 2.0
     SOIL_WLTSMC = 0.439
     SOIL_SMCMAX = 0.439
     SOIL_SLOP = 0.05
@@ -1199,6 +1173,9 @@ class CFEValues(str, enum.Enum):
     CGW = 0.000018
     EXPON = 3
     REFKDT = 1
+    IS_AET = False
+    SOIL_LAYER_DEPTHS = list((0.1, 0.4, 1.0, 2.0))
+    MAX_ROOTZONE_LAYER = 2.0
 
 
 class CFE(BaseModel):
@@ -1206,20 +1183,16 @@ class CFE(BaseModel):
 
     model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
     catchment: str = Field(..., description="The catchment ID")
-    forcing_file: str = Field(default=CFEValues.FORCINGFILE.value, description="NA")
-    verbosity: int = Field(default=CFEValues.VERBOSITY.value, description="NA")
     surface_partitioning_scheme: str = Field(..., description="Selects Xinanjiang or Schaake")
     surface_runoff_scheme: str = Field(
         default=CFEValues.SRFC_RUNOFF_SCHEME.value,
         description="Accepts  1 or GIUH for GIUH and  2 or NASH_CASCADE for Nash Cascade; default is GIUH, version 1 is GIUH, Version 2 is Nash",
     )
-    debug: int = Field(default=CFEValues.DEBUG.value, description="NA")
-    num_timesteps: int = Field(default=CFEValues.NUM_TIMESTEPS.value, description="NA")
-    is_sft_coupled: str = Field(
-        ...,
+    is_sft_coupled: bool = Field(
+        False,
         description="Optional. Turns on/off the CFE coupling with the SoilFreezeThaw. If this parameter is defined to be True (or 1) in the config file and surface_partitioning_scheme=Schaake, then ice_content_threshold also needs to be defined in the config file.",
     )
-    ice_content_thresh: float = Field(
+    ice_content_thresh: Optional[float] = Field(
         default=CFEValues.ICE_CONTENT_THR.value,
         description="Optional. This represents the ice content above which soil is impermeable. If this is_sft_couple is defined to be True (or 1) in the config file and surface_partitioning_scheme=Schaake, then this also needs to be defined in the config file.",
     )
@@ -1284,36 +1257,35 @@ class CFE(BaseModel):
         default=CFEValues.GIUH.value,
         description="Giuh (geomorphological instantaneous unit hydrograph) ordinates in dt time steps",
     )
-    a_Xinanjiang_inflection_point_parameter: str = Field(
-        default=CFEValues.A_XINANJIANG_INFLECT.value,
+    a_Xinanjiang_inflection_point_parameter: Optional[float] = Field(
+        ...,
         description="When surface_water_partitioning_scheme=Xinanjiang",
     )
-    b_Xinanjiang_shape_parameter: str = Field(
-        default=CFEValues.B_XINANJIANG_SHAPE.value,
+    b_Xinanjiang_shape_parameter: Optional[float] = Field(
+        ...,
         description="When surface_water_partitioning_scheme=Xinanjiang",
     )
-    x_Xinanjiang_shape_parameter: str = Field(
-        default=CFEValues.X_XINANJIANG_SHAPE.value,
+    x_Xinanjiang_shape_parameter: Optional[float] = Field(
+        ...,
         description="When surface_water_partitioning_scheme=Xinanjiang",
     )
-    urban_decimal_fraction: str = Field(..., description="When surface_water_partitioning_scheme=Xinanjiang")
+    urban_decimal_fraction: Optional[float] = Field(..., description="When surface_water_partitioning_scheme=Xinanjiang")
     refkdt: float = Field(
         default=CFEValues.REFKDT.value,
         description="Reference Soil Infiltration Parameter (used in runoff formulation)",
     )
     soil_params_depth: float = Field(default=CFEValues.SOIL_DEPTH.value, description="Soil depth")
+    is_aet_rootzone: bool = Field(default=CFEValues.IS_AET.value, description="Turn on rootzone AET")
+    soil_layer_depths: Optional[list[float]] = Field(default=CFEValues.SOIL_LAYER_DEPTHS.value, description="array of depths from the surface for AET")
+    max_rootzone_layer: Optional[float] = Field(default=CFEValues.MAX_ROOTZONE_LAYER.value, description="layer of the soil that is the maximum root zone depth")
 
     def to_bmi_config(self) -> list[str]:
         """Convert the model back to the original config file format"""
         nash_storage = ",".join([str(n) for n in self.nash_storage])
         giuh_ordinates = ",".join([str(giuh) for giuh in self.giuh_ordinates])
         return [
-            f"forcing_file: {self.forcing_file}",
-            f"verbosity: {self.verbosity}",
             f"surface_partitioning_scheme: {self.surface_partitioning_scheme}",
             f"surface_runoff_scheme: {self.surface_runoff_scheme}",
-            f"debug: {self.debug}",
-            f"num_timesteps: {self.num_timesteps}",
             f"is_sft_coupled: {self.is_sft_coupled}",
             f"ice_content_thresh: {self.ice_content_thresh}",
             f"soil_params.b: {self.soil_params_b}",

--- a/src/icefabric/schemas/modules.py
+++ b/src/icefabric/schemas/modules.py
@@ -4,7 +4,7 @@ import enum
 from pathlib import Path
 from typing import Literal, Protocol, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class NWMProtocol(Protocol):
@@ -1174,7 +1174,7 @@ class CFEValues(enum.Enum):
     EXPON = 3
     REFKDT = 1
     IS_AET = False
-    SOIL_LAYER_DEPTHS = list((0.1, 0.4, 1.0, 2.0))
+    SOIL_LAYER_DEPTHS = [0.1, 0.4, 1.0, 2.0]
     MAX_ROOTZONE_LAYER = 2.0
 
 

--- a/tests/app/test_topoflow_albedo_router.py
+++ b/tests/app/test_topoflow_albedo_router.py
@@ -1,6 +1,7 @@
 from icefabric.schemas.modules import AlbedoValues
+import pytest
 
-
+@pytest.mark.skip(reason="albedo not used at this time")
 def test_albedo_endpoint(client):
     """Test: GET /v2/modules/topoflow/albedo - all valid arguments"""
     for landcover, albedo in AlbedoValues.__members__.items():
@@ -8,7 +9,7 @@ def test_albedo_endpoint(client):
         assert response.status_code == 200
         assert response.text == str(albedo.value)
 
-
+@pytest.mark.skip(reason="albedo not used at this time")
 def test_albedo_endpoint__422(client):
     """Test: GET /v2/modules/topoflow/albedo - fails validator"""
     response = client.get("/v1/modules/topoflow/albedo?landcover=nope")


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions
Added code for the UEB and CFE endpoints in router.py.  Added the rootzone AET optional parameters to CFE. 
-

## Removals
Removed some non-parameter items like verbosity, debug, start/end times, paths to files that should be filled in by NWM.
Removed:

CFE:
forcing_file
verbosity
debug
num_timesteps

SFT:
verbosity
end_time
dt

SMP:
verbosity

LSTM:
basin_name 
verbose
timestep
train_cfg_file

LASAM:
verbosity
endtime
timestep
soil_params_file

noahowp:
startdate
enddate
forcing_filename
output_filename
parameter_dir
dt

TopModel:
yes_print_output

topoflow:
dt
start_time
end_time
forcing_file

Per Jeff:  renamed 'output_param' to 'output_parameters', remove 'rl_gages' and 'rl_NHDWaterbodyComID' from bmi_param, and removed "waterbody": "rl_NHDWaterbodyComID", "gages": "rl_gages" from ntwk_columns
-

## Changes
Made some corrections to parameters, fixed data types for CFE and SMP to allow Pydantic to work better with optional parameters such as the parameters that are added when CFE-X is run and the rainfall runoff model specific parameter for SMP.
-

## Testing

1.  Tested all module IPE endpoints with particular attention spent on CFE and SMP where I made updates to how the optional parameters are handled.  

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [ x] Code can be automatically merged (no conflicts)
- [ x] Code follows project standards (link if applicable)
- [ x] Passes all existing automated tests
- [x ] Any _change_ in functionality is tested
- [x ] New functions are documented (with a description, list of inputs, and expected output)
- [na ] Placeholder code is flagged / future todos are captured in comments
- [na ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
