### PR TITLE
Patch: removed hardcoded GLUE catalog references 

### DIFF
--- a/app/streamlit/helpers.py
+++ b/app/streamlit/helpers.py
@@ -4,7 +4,6 @@ import geopandas as gpd
 import pandas as pd
 import polars as pl
 import streamlit as st
-from pyiceberg.catalog import load_catalog
 from pyiceberg.expressions import In
 from shapely.geometry import box
 
@@ -17,14 +16,13 @@ domain_class_map = {"representative": RepresentativeRasXS, "conflated": Conflate
 
 
 @st.cache_data(show_spinner=False)
-def get_data(xs_dom, subset):
+def get_data(_catalog, xs_dom, subset):
     """Helper to call XS subsetting function. Caches the results."""
-    catalog = load_catalog("glue")
     if type(subset) is str:
-        xs_gdf = subset_xs(catalog=catalog, xstype=xs_dom, identifier=subset)
+        xs_gdf = subset_xs(catalog=_catalog, xstype=xs_dom, identifier=subset)
     elif type(subset) is list:
         bbox = box(*subset)
-        xs_gdf = subset_xs(catalog=catalog, xstype=xs_dom, bbox=bbox)
+        xs_gdf = subset_xs(catalog=_catalog, xstype=xs_dom, bbox=bbox)
     return xs_gdf
 
 
@@ -35,17 +33,16 @@ def convert_for_download(gdf, tmp_path):
     gpd.GeoDataFrame(gdf).to_file(tmp_path, driver="GPKG", mode="w")
 
 
-def format_xs_map(xs_gdf):
+def format_xs_map(_catalog, xs_gdf):
     """Helper to create/format a folium map to display the cross-sectional data."""
-    catalog = load_catalog("glue")
     # Pull and filter reference divides/flowpaths from the catalog
     reference_divides = to_geopandas(
-        catalog.load_table("conus_reference.reference_divides")
+        _catalog.load_table("conus_reference.reference_divides")
         .scan(row_filter=In("flowpath_id", xs_gdf["flowpath_id"]))
         .to_pandas()
     )
     reference_flowpaths = to_geopandas(
-        catalog.load_table("conus_reference.reference_flowpaths")
+        _catalog.load_table("conus_reference.reference_flowpaths")
         .scan(row_filter=In("flowpath_id", xs_gdf["flowpath_id"]))
         .to_pandas()
     )

--- a/app/streamlit/hydrofabric_dash.py
+++ b/app/streamlit/hydrofabric_dash.py
@@ -13,6 +13,8 @@ from icefabric.hydrofabric import subset_nhf
 
 st.session_state.NHF_SUBSET_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
+catalog = st.session_state.catalog
+
 st.set_page_config(page_title="NGWPC Hydrofabric", layout="wide")
 st.title("NGWPC Hydrofabric")
 st.write("Information for the NextGen Water Prediction Capability Hydrofabric")
@@ -54,11 +56,11 @@ if subset_submit and submit_valid:
                     f"**Subsetting hydrofabric ({subset_type} {subset_user_sel})...**", show_time=True
                 ):
                     if subset_type == "Flowpath ID":
-                        subset_nhf(catalog=True, flowpath_id=subset_user_sel, output=subset_gpkg_file)
+                        subset_nhf(catalog=catalog, flowpath_id=subset_user_sel, output=subset_gpkg_file)
                     elif subset_type == "Gage ID":
-                        subset_nhf(catalog=True, gage_id=subset_user_sel, output=subset_gpkg_file)
+                        subset_nhf(catalog=catalog, gage_id=subset_user_sel, output=subset_gpkg_file)
                     elif subset_type == "VPU ID":
-                        subset_nhf(catalog=True, vpu_id=subset_user_sel, output=subset_gpkg_file)
+                        subset_nhf(catalog=catalog, vpu_id=subset_user_sel, output=subset_gpkg_file)
             with r_col:
                 post_transient_success_msg("Subsetting complete!")
             subset_successful = True

--- a/app/streamlit/ras_xs_dash.py
+++ b/app/streamlit/ras_xs_dash.py
@@ -25,6 +25,8 @@ tmp_path = temp_dir / "xs_subset.gpkg"
 
 st.set_page_config(page_title="RAS XS", layout="wide")
 
+catalog = st.session_state.catalog
+
 with st.container():
     st.title("RAS XS")
     st.markdown(
@@ -69,9 +71,9 @@ if l_col.button("Submit"):
     try:
         with st.spinner(text="Fetching data..."):
             if xs_id is not None:
-                xs_gdf = get_data(xs_dom, xs_id)
+                xs_gdf = get_data(catalog, xs_dom, xs_id)
             elif all(var is not None for var in bbox_list):
-                xs_gdf = get_data(xs_dom, bbox_list)
+                xs_gdf = get_data(catalog, xs_dom, bbox_list)
 
         if xs_gdf.empty:
             l_col.error(
@@ -80,7 +82,7 @@ if l_col.button("Submit"):
         else:
             # Format and display map
             with st.spinner(text="Generating map..."):
-                xs_map = format_xs_map(xs_gdf)
+                xs_map = format_xs_map(catalog, xs_gdf)
                 r_col.markdown("#### Map")
                 with r_col:
                     st_folium(fig=xs_map, width=725, returned_objects=[])

--- a/app/streamlit/streamlit.py
+++ b/app/streamlit/streamlit.py
@@ -4,27 +4,48 @@ import sys
 import tempfile
 
 import streamlit as st
+from pyiceberg.catalog import load_catalog
 
 from icefabric.helpers.creds import load_creds
 
 # Deploy environment default is "test"
 deploy_env = "test"
 args_provided = sys.argv[1:]
+
+# Parse deploy-env argument
 if any("deploy-env=" in a for a in args_provided):
     try:
         deploy_env_pass = " ".join(args_provided).split("deploy-env=")[1].split()[0]
-        if deploy_env_pass.lower() in ["t", "test", "p", "prod", "production"]:
+        if deploy_env_pass.lower() in ["t", "test", "p", "prod", "production", "l", "local"]:
             deploy_env = deploy_env_pass.lower()
     except IndexError:
-        # No deploy env provided, use default
         pass
 
-# Load creds/env details.
-if str(os.environ.get("ICEFABRIC_DEPLOY_ENV")).lower() in ["t", "test", "p", "prod", "production"]:
-    # Override the deploy env. Allows for specifying the env when running a docker container
-    load_creds(os.environ["ICEFABRIC_DEPLOY_ENV"].lower())
-else:
-    load_creds(deploy_env)
+# Check environment variable override
+if str(os.environ.get("ICEFABRIC_DEPLOY_ENV")).lower() in [
+    "t",
+    "test",
+    "p",
+    "prod",
+    "production",
+    "l",
+    "local",
+]:
+    deploy_env = os.environ["ICEFABRIC_DEPLOY_ENV"].lower()
+
+# Set catalog type based on deploy environment
+catalog_type = "sql" if deploy_env in ["l", "local"] else "glue"
+
+# Load credentials
+load_creds(deploy_env)
+
+# Load catalog and store in session state
+if "catalog" not in st.session_state:
+    st.session_state.catalog = load_catalog(catalog_type)
+if "catalog_type" not in st.session_state:
+    st.session_state.catalog_type = catalog_type
+if "deploy_env" not in st.session_state:
+    st.session_state.deploy_env = deploy_env
 
 modules = {
     "": [st.Page("home.py", title="Home")],
@@ -33,8 +54,7 @@ modules = {
         st.Page("ras_xs_dash.py", title="RAS XS", icon=":material/arrow_range:"),
     ],
 }
-# Favicon image: "Iceberg" designed by Freepik
-# source: https://www.flaticon.com/free-icon/iceberg_2466034 - Free for use with attribution.
+
 st.logo("app/streamlit/resources/iceberg_favicon.png", size="large", link=None, icon_image=None)
 st.set_page_config(
     page_title="icefabric", layout="wide", page_icon="app/streamlit/resources/iceberg_favicon.png"
@@ -46,6 +66,7 @@ if "initialized" not in st.session_state or not st.session_state.initialized:
         st.session_state["NHF_SUBSET_OUTPUT_DIR"] = (
             pathlib.Path(tempfile.gettempdir()) / "icefabric_streamlit_subsets"
         )
+    st.session_state.NHF_SUBSET_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     for item in st.session_state.NHF_SUBSET_OUTPUT_DIR.iterdir():
         if item.is_dir():
             item.rmdir(missing_ok=True)

--- a/src/icefabric/hydrofabric/subset_nhf.py
+++ b/src/icefabric/hydrofabric/subset_nhf.py
@@ -9,10 +9,9 @@ import geopandas as gpd
 import polars as pl
 import pyogrio
 import rustworkx as rx
-from pyiceberg.catalog import Catalog, load_catalog
+from pyiceberg.catalog import Catalog
 
 from icefabric.cli.streamflow import NoResultsFoundError
-from icefabric.helpers.creds import load_creds
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -304,7 +303,7 @@ def subset_nhf(
     flowpath_id: int | None = None,
     gage_id: str | None = None,
     vpu_id: str | None = None,
-    catalog: bool = False,
+    catalog: Catalog | None = None,
     parquet_dir: Path | None = None,
     output: Path | None = None,
 ) -> dict[str, gpd.GeoDataFrame]:
@@ -340,19 +339,14 @@ def subset_nhf(
         sys.exit(1)
 
     # Initialize data source
-    iceberg_catalog: Catalog | None = None
-    if catalog:
-        logger.debug("Using Iceberg catalog...")
-        load_creds()
-        iceberg_catalog = load_catalog("glue")
-    else:
+    if catalog is None:
         if parquet_dir is None:
             logger.error("Must provide --parquet-dir when not using --catalog")
             sys.exit(1)
         if not parquet_dir.exists():
             raise FileNotFoundError(f"Parquet directory not found: {parquet_dir}")
 
-    source = HydrofabricSource(parquet_dir=parquet_dir, catalog=iceberg_catalog)
+    source = HydrofabricSource(parquet_dir=parquet_dir, catalog=catalog)
 
     # ==================================================================
     # VPU PATH - no graph needed, just filter by vpu_id


### PR DESCRIPTION
### Additions

For the streamlit dashboard all references to the pyiceberg catalog were hardcoded to `glue`

this change adds the `local` flag to the `deploy-env` tag, and added a catalog variable into the state

fixed missing `/tmp` dir 
<img width="2393" height="372" alt="image" src="https://github.com/user-attachments/assets/b9637e6c-e89a-435d-b0b9-c9f8e3dbe1f0" />


to test this, please export the catalog locally and start up the streamlit dashboard (with test account `.env` settings)

```
uv run python tools/iceberg/export_catalog.py --namespace nhf
uv run python tools/iceberg/export_catalog.py --namespace conus_reference
uv run python tools/iceberg/export_catalog.py --namespace ras_xs
uv run streamlit run app/streamlit/streamlit.py deploy-env=local
```