### PR TITLE
Patch to allow for legacy domain names when querying old HF

### DIFF
--- a/app/routers/nwm_modules/router.py
+++ b/app/routers/nwm_modules/router.py
@@ -239,9 +239,7 @@ async def get_lasam_ipes(
     soil_params_file: str = Query(
         "vG_default_params_HYDRUS.dat",
         description="Name of the Van Genuchton soil parameters file. Note: This is the filename that gets returned by HF API's utility script get_hydrus_data().",
-        openapi_examples={
-            "lasam_example": {"summary": "LASAM Example", "value": "vG_default_params_HYDRUS.dat"}
-        },
+        openapi_examples={"lasam_example": {"summary": "LASAM Example", "value": "vG_default_params_HYDRUS.dat"}},
     ),
     catalog: Catalog = Depends(get_catalog),
     network_graphs=Depends(get_graphs),
@@ -638,7 +636,7 @@ async def get_calibratable_parameter_metadata(
         examples=["01010000"],
         openapi_examples={"Sample Gage": {"summary": "Sample Gage", "value": "01010000"}},
     ),
-    domain: str = Query(
+    domain: HydrofabricDomains | None = Query(
         None,
         description="The iceberg namespace used to query the hydrofabric.",
         openapi_examples={
@@ -699,7 +697,7 @@ async def get_calibratable_parameter_metadata(
         modules=modules,
         catalog=catalog,
         gage_id=f"gages-{gage_id}" if domain == HydrofabricDomains.CONUS else gage_id,
-        domain=domain,
+        domain=domain.value if domain else None,
         graph=network_graphs[domain] if domain == HydrofabricDomains.CONUS else None,
     )
 

--- a/src/icefabric/schemas/hydrofabric.py
+++ b/src/icefabric/schemas/hydrofabric.py
@@ -51,6 +51,18 @@ class HydrofabricDomains(str, Enum):
     PRVI = "prvi_hf"
     NHF = "nhf"
 
+    @classmethod
+    def _missing_(cls, value):
+        """Accept user-friendly domain names as aliases."""
+        aliases = {
+            "CONUS": cls.CONUS,
+            "Alaska": cls.AK,
+            "Hawaii": cls.HI,
+            "Puerto_Rico": cls.PRVI,
+            "Great_Lakes": cls.GL,
+        }
+        return aliases.get(value)
+
 
 class StreamflowDataSources(str, Enum):
     """The data sources used for hourly streamflow data"""


### PR DESCRIPTION
This is a small patch to allow for a user to use the legacy api domain names to access HF 2.3 data. Future releases will modify this behavior so that legacy domain names can be used to access both HF and NHF with the two hydrofabrics being differentiated by parsing part of a "version" query parameter.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
