### PR TITLE
Restrict python to <=3.12.8 to avoid issues with missing wheels

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,7 +15,7 @@ permissions:
 
 env:
     REGISTRY: ghcr.io
-    PYTHON_VERSION: '3.12'
+    PYTHON_VERSION: '3.12.8'
 
 jobs:
     setup:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,7 +15,7 @@ permissions:
 
 env:
     REGISTRY: ghcr.io
-    PYTHON_VERSION: '3.13'
+    PYTHON_VERSION: '3.12'
 
 jobs:
     setup:
@@ -69,7 +69,7 @@ jobs:
     #       - name: Set up Python
     #         uses: astral-sh/setup-uv@v5
     #         with:
-    #             python-version: "3.13"
+    #             python-version: "3.12"
     #             cache-dependency-glob: uv.lock pyproject.toml
     #
     #       - name: Install dependencies
@@ -88,7 +88,7 @@ jobs:
         needs: setup
         strategy:
             matrix:
-                python-version: ['3.11', '3.12', '3.13']
+                python-version: ['3.11', '3.12']
         steps:
           - name: Checkout code
             uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ name = "icefabric"
 version = "2025.10.1"
 description = "An Apache Iceberg + Icechunk implementation of Hydrofabric data services"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<=3.12"
 license = { file = "LICENSE" }
 authors = [
   { name = "Tadd Bindas", email = "tadd.bindas@ertcorp.com" },
@@ -54,19 +54,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-docs = [
-  "mkdocs-material==9.6.14",
-  "sympy==1.14.0"
-]
-app = [
-  "pydantic==2.11.5",
-  "pydantic-settings==2.10.1",
-  "python-dotenv==1.1.0",
-]
-cli = [
-  "dask==2025.9.1",
-  "click==8.2.1",
-]
+docs = ["mkdocs-material==9.6.14", "sympy==1.14.0"]
+app = ["pydantic==2.11.5", "pydantic-settings==2.10.1", "python-dotenv==1.1.0"]
+cli = ["dask==2025.9.1", "click==8.2.1"]
 examples = [
   "httpx==0.28.1",
   "ipykernel==6.29.5",
@@ -79,13 +69,9 @@ icechunk_extras = [
   "netCDF4==1.7.2",
   "tifffile==2025.5.21",
   "rioxarray==0.19.0",
-  "virtualizarr==1.3.2"
+  "virtualizarr==1.3.2",
 ]
-streamlit = [
-  "Shapely==2.1.2",
-  "streamlit==1.51.0",
-  "streamlit-folium==0.25.3"
-]
+streamlit = ["Shapely==2.1.2", "streamlit==1.51.0", "streamlit-folium==0.25.3"]
 tools = [
   "llvmlite==0.44.0",
   "numba==0.61.2",
@@ -197,8 +183,8 @@ warn_unused_ignores = true
 pythonpath = ["tests"]
 testpaths = ["tests"]
 filterwarnings = [
-    #"ignore::zarr.errors.UnstableSpecificationWarning",
-    "ignore::FutureWarning:pyproj",
-    "ignore::DeprecationWarning:pyogrio",
-    "ignore:The 'shapely.geos' module is deprecated:DeprecationWarning",
+  #"ignore::zarr.errors.UnstableSpecificationWarning",
+  "ignore::FutureWarning:pyproj",
+  "ignore::DeprecationWarning:pyogrio",
+  "ignore:The 'shapely.geos' module is deprecated:DeprecationWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ name = "icefabric"
 version = "2025.10.1"
 description = "An Apache Iceberg + Icechunk implementation of Hydrofabric data services"
 readme = "README.md"
-requires-python = ">=3.11,<=3.12"
+requires-python = ">=3.11,<=3.12.8"
 license = { file = "LICENSE" }
 authors = [
   { name = "Tadd Bindas", email = "tadd.bindas@ertcorp.com" },


### PR DESCRIPTION
When testing in fresh Ubuntu/Debian installs, I found that by default `uv sync --all-extras` tried to use Python 3.13 or 3.14 on my machines. While it built OK, there were a few wheels missing that usually ended up slowing things down significantly. Particularly, Avro ended up using a fallback Python-only implementation. 

This change should make things be a bit more predictable for first-time installs.  

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [X] Linux
- [X] Browser

### Accessibility

- [X] Keyboard friendly
- [X] Screen reader friendly

### Other

- [X] Is useable without CSS
- [X] Is useable without JS
- [X] Flexible from small to large screens
- [X] No linting errors or warnings
- [X] JavaScript tests are passing
