### PR TITLE
NGWPC-9448 - Add RAS XS and NHF dashboard 3D channel mapping support

### DIFF
--- a/app/streamlit/helpers.py
+++ b/app/streamlit/helpers.py
@@ -1,7 +1,10 @@
+import statistics
 import time
 
 import folium
 import geopandas as gpd
+import matplotlib as mpl
+import numpy as np
 import pandas as pd
 import polars as pl
 import streamlit as st
@@ -15,29 +18,29 @@ from icefabric.schemas.iceberg_tables.ras_xs import ConflatedRasXS, Representati
 
 domain_class_map = {"representative": RepresentativeRasXS, "conflated": ConflatedRasXS}
 
-LAYER_FOLIUM_STYLING_MAP = {
+STYLE_MAP = {
     "divides": {
         "styling": {
             "color": "grey",
-            "weight": 1.5,
+            "weight": 2,
             "opacity": 0.5,
-            "fillOpacity": 0.5,
+            "fillOpacity": 0.33,
             "dashArray": [5, 5],
         },
         "highlight_styling": {
-            "weight": 3,
-            "opacity": 0.8,
-            "fillOpacity": 0.8,
+            "weight": 4,
+            "opacity": 0.75,
+            "fillOpacity": 0.5,
         },
     },
     "flowpaths": {
         "styling": {
             "color": "darkblue",
-            "weight": 4,
+            "weight": 3,
             "opacity": 1,
         },
         "highlight_styling": {
-            "weight": 8,
+            "weight": 6,
         },
     },
     "nexus": {"marker_styling": folium.Marker(icon=folium.Icon(color="orange", icon="filter"))},
@@ -54,7 +57,57 @@ LAYER_FOLIUM_STYLING_MAP = {
         },
     },
     "virtual_nexus": {"marker_styling": folium.Marker(icon=folium.Icon(color="green", icon="filter"))},
+    "ras_xs": {
+        "styling": {
+            "color": "black",
+            "weight": 2,
+            "opacity": 1,
+        },
+        "highlight_styling": {
+            "weight": 4,
+        },
+    },
 }
+
+
+def depth_to_gradient(val, domain="NHF", min_val=0, max_val=6.5, start_color="#7073FF", end_color="#0B0B1B"):
+    """Given a flowpath depth value, return a hex color code representing its position on a gradient"""
+    if val is None:
+        return "#FFFFFF"  # White for null values
+    if domain == "XS":
+        max_val = 25
+    if val > max_val:
+        val = max_val
+
+    # Normalize value between 0 and 1
+    norm = (val - min_val) / (max_val - min_val)
+    c1 = mpl.colors.to_rgb(start_color)
+    c2 = mpl.colors.to_rgb(end_color)
+    # Linear interpolation
+    rgb = [(1 - norm) * c1[i] + norm * c2[i] for i in range(3)]
+    return mpl.colors.to_hex(rgb)
+
+
+def normalize_width(val, domain="NHF", min=0, max=384, nmin=2, nmax=50):
+    """Given a flowpath width value, normalize it to a new range (for styling)"""
+    if val is None:
+        return 1  # Width for null values
+    if domain == "XS":
+        max = 1224
+    if val > max:
+        return nmax
+    else:
+        return round(nmin + (((val - min) * (nmax - nmin)) / (max - min)))
+
+
+def set_id_fields_as_strings(gdf):
+    """Helper to ensure id fields are of type string."""
+    id_field_names = [c for c in gdf.columns.tolist() if c.endswith("_id") and c != "vpu_id"]
+    for fn in id_field_names:
+        if gdf[fn].dtype == "int64" or gdf[fn].dtype == "float64":
+            # Convert floats/ints to string, handling NaNs
+            gdf[fn] = gdf[fn].apply(lambda x: f"{int(x)}" if pd.notna(x) else np.nan)
+    return gdf
 
 
 @st.cache_data(show_spinner=False)
@@ -75,31 +128,135 @@ def convert_for_download(gdf, tmp_path):
     gpd.GeoDataFrame(gdf).to_file(tmp_path, driver="GPKG", mode="w")
 
 
-def format_xs_map(_catalog, xs_gdf):
+def format_xs_map(_catalog, xs_gdf, domain):
     """Helper to create/format a folium map to display the cross-sectional data."""
-    # Pull and filter reference divides/flowpaths from the catalog
+    # Create base map
+    m = folium.Map(tiles=folium.TileLayer(tiles="Cartodb Positron", control=False))
+
+    # Format cross-sectional data
+    ras_xs = xs_gdf.to_crs(epsg=4326)
+
+    # Pull and format reference layers
     reference_divides = to_geopandas(
         _catalog.load_table("conus_reference.reference_divides")
         .scan(row_filter=In("flowpath_id", xs_gdf["flowpath_id"]))
         .to_pandas()
-    )
+    ).to_crs(epsg=4326)
     reference_flowpaths = to_geopandas(
         _catalog.load_table("conus_reference.reference_flowpaths")
         .scan(row_filter=In("flowpath_id", xs_gdf["flowpath_id"]))
         .to_pandas()
+    ).to_crs(epsg=4326)
+
+    # Ensure ID fields are strings for proper display in popups
+    ras_xs = set_id_fields_as_strings(ras_xs)
+    reference_divides = set_id_fields_as_strings(reference_divides)
+    reference_flowpaths = set_id_fields_as_strings(reference_flowpaths)
+
+    # Sort dataframes by flowpath_id for consistent ordering
+    ras_xs = ras_xs.sort_values(by="flowpath_id", ascending=True)
+    reference_flowpaths = reference_flowpaths.sort_values(by="flowpath_id", ascending=True)
+    reference_divides = reference_divides.sort_values(by="flowpath_id", ascending=True)
+
+    # Sometimes even representative XS data can have multiple entries per flowpath_id
+    unique_flowpaths = ras_xs["flowpath_id"].unique().tolist()
+
+    # Add width and depth to reference flowpaths
+    avg_widths, avg_depths = [], []
+    for fp in unique_flowpaths:
+        avg_widths.append(statistics.mean(ras_xs[ras_xs["flowpath_id"] == fp].TW.tolist()))
+        if domain == "representative":
+            avg_depths.append(statistics.mean(ras_xs[ras_xs["flowpath_id"] == fp].Y.tolist()))
+        elif domain == "conflated":
+            avg_depths.append(statistics.mean(ras_xs[ras_xs["flowpath_id"] == fp].Ym.tolist()))
+    reference_flowpaths["width"] = avg_widths
+    reference_flowpaths["depth"] = avg_depths
+
+    # Fit map to data bounds
+    min_points = [(row.miny, row.minx) for row in reference_flowpaths.geometry.bounds.itertuples()]
+    max_points = [(row.maxy, row.maxx) for row in reference_flowpaths.geometry.bounds.itertuples()]
+    lat_lon_coll = min_points + max_points
+    m.fit_bounds(lat_lon_coll)
+
+    # Reference divides GeoJSON layer
+    div_popup_fields = [col for col in reference_divides.columns if col != "geometry"]
+    div_style = STYLE_MAP["divides"].get("styling", {})
+    div_hl_style = STYLE_MAP["divides"].get("highlight_styling", {})
+    ref_div_poly = folium.GeoJson(
+        data=reference_divides,
+        popup=folium.GeoJsonPopup(fields=list(div_popup_fields[:25])),
+        tooltip=folium.GeoJsonTooltip(
+            fields=[div_popup_fields[0]],
+            aliases=["Reference Divide ID:"],
+        ),
+        style_function=lambda x: div_style,
+        highlight_function=lambda x: div_hl_style,
     )
 
-    # Convert all data to the EPSG:4326 coordinate reference system
-    reference_divides = reference_divides.to_crs(epsg=4326)
-    reference_flowpaths = reference_flowpaths.to_crs(epsg=4326)
-    gdf = xs_gdf.to_crs(epsg=4326)
+    # Reference/3D flowpaths GeoJSON layers
+    fp_popup_fields = [col for col in reference_flowpaths.columns if col != "geometry"]
+    fp_style = STYLE_MAP["flowpaths"].get("styling", {})
+    fp_hl_style = STYLE_MAP["flowpaths"].get("highlight_styling", {})
+    ref_fp_poly = folium.GeoJson(
+        data=reference_flowpaths,
+        popup=folium.GeoJsonPopup(fields=list(fp_popup_fields[:25])),
+        tooltip=folium.GeoJsonTooltip(
+            fields=[fp_popup_fields[0]],
+            aliases=["Reference Flowpath ID:"],
+        ),
+        style_function=lambda x: fp_style,
+        highlight_function=lambda x: fp_hl_style,
+    )
+    three_dim_fp_poly = folium.GeoJson(
+        data=reference_flowpaths,
+        popup=folium.GeoJsonPopup(fields=list(fp_popup_fields[:25])),
+        tooltip=folium.GeoJsonTooltip(
+            fields=[fp_popup_fields[0], "width", "depth"],
+            aliases=["Reference Flowpath ID:", "Width (ft):", "Depth (ft):"],
+            localize=True,
+        ),
+        style_function=lambda x: fp_style
+        | {
+            "weight": normalize_width(x["properties"]["width"], domain="XS"),
+            "color": depth_to_gradient(x["properties"]["depth"], domain="XS"),
+        },
+        highlight_function=lambda x: fp_hl_style
+        | {
+            "weight": normalize_width(x["properties"]["width"], domain="XS") + 4,
+        },
+    )
 
-    ref_div_ex = reference_divides.explore(color="grey")
-    ref_flo_ex = reference_flowpaths.explore(m=ref_div_ex, color="blue")
+    # Cross-sectional data GeoJSON layer
+    ras_xs_popup_fields = [col for col in ras_xs.columns if col != "geometry"]
+    ras_xs_style = STYLE_MAP["ras_xs"].get("styling", {})
+    ras_xs_hl_style = STYLE_MAP["ras_xs"].get("highlight_styling", {})
+    ras_xs_poly = folium.GeoJson(
+        data=ras_xs,
+        popup=folium.GeoJsonPopup(fields=list(ras_xs_popup_fields[:25])),
+        tooltip=folium.GeoJsonTooltip(
+            fields=[ras_xs_popup_fields[0]],
+            aliases=["XS Flowpath ID:"],
+        ),
+        style_function=lambda x: ras_xs_style,
+        highlight_function=lambda x: ras_xs_hl_style,
+    )
 
-    # Final Map
-    xs_map = gdf.explore(m=ref_flo_ex, color="black")
-    return xs_map
+    # Add layers to map with layer control
+    m.add_child(folium.FeatureGroup(name="Reference Divides").add_child(ref_div_poly))
+    m.add_child(folium.FeatureGroup(name="Reference Flowpaths").add_child(ref_fp_poly))
+    m.add_child(folium.FeatureGroup(name="RAS XS").add_child(ras_xs_poly))
+    m.add_child(folium.FeatureGroup(name="3D Flowpaths", show=False).add_child(three_dim_fp_poly))
+
+    # Move layer control to bottom right and add fullscreen button
+    folium.LayerControl(position="bottomright").add_to(m)
+    folium.plugins.Fullscreen(
+        position="topright",
+        title="Expand me",
+        title_cancel="Exit me",
+        force_separate_button=True,
+    ).add_to(m)
+
+    return m
 
 
 def create_table_from_schema(iceberg_schema):

--- a/app/streamlit/hydrofabric_dash.py
+++ b/app/streamlit/hydrofabric_dash.py
@@ -1,16 +1,17 @@
 import folium
 import geopandas as gpd
-import numpy as np
-import pandas as pd
 import streamlit as st
 from botocore.exceptions import ClientError
 from streamlit_folium import st_folium
 
 from app.streamlit.helpers import (
-    LAYER_FOLIUM_STYLING_MAP,
+    STYLE_MAP,
+    depth_to_gradient,
     display_nhf_schemas,
     load_hf_gpkg,
+    normalize_width,
     post_transient_success_msg,
+    set_id_fields_as_strings,
     validate_nhf_subset_query,
 )
 from app.streamlit.tooltips import hf_subset_options_explanation
@@ -107,6 +108,7 @@ if subset_submit and submit_valid:
                 m = folium.Map(tiles=folium.TileLayer(tiles="Cartodb Positron", control=False))
                 lat_lon_coll = [(row.lat, row.lon) for row in subset_dfs["divides"].to_pandas().itertuples()]
                 m.fit_bounds(lat_lon_coll)
+                fp_data = None
                 for layer_name, df in subset_dfs.items():
                     if "geometry" in df.columns and not df.is_empty():
                         df = df.to_pandas()
@@ -117,30 +119,24 @@ if subset_submit and submit_valid:
                         ).to_crs(epsg=4326)
 
                         # Ensure ID fields are strings for proper display in popups
-                        id_field_names = [
-                            c for c in gdf.columns.tolist() if c.endswith("_id") and c != "vpu_id"
-                        ]
-                        for fn in id_field_names:
-                            if gdf[fn].dtype == "int64" or gdf[fn].dtype == "float64":
-                                # Convert floats/ints to string, handling NaNs
-                                gdf[fn] = df[fn].apply(lambda x: f"{int(x)}" if pd.notna(x) else np.nan)
+                        gdf = set_id_fields_as_strings(gdf)
 
-                        styling = LAYER_FOLIUM_STYLING_MAP[layer_name].get("styling", {})
-                        highlight_styling = LAYER_FOLIUM_STYLING_MAP[layer_name].get("highlight_styling", {})
-                        marker_styling = LAYER_FOLIUM_STYLING_MAP[layer_name].get("marker_styling", None)
-                        popup_fields = list(gdf.columns)
-                        popup_fields.remove("geometry")
+                        if layer_name == "flowpaths":
+                            fp_data = gdf.copy()
+                        style = STYLE_MAP[layer_name].get("styling", {})
+                        hl_style = STYLE_MAP[layer_name].get("highlight_styling", {})
+                        marker_style = STYLE_MAP[layer_name].get("marker_styling", None)
+                        popup_fields = [c for c in gdf.columns if c != "geometry"]
                         gdf_poly = folium.GeoJson(
                             data=gdf,
-                            popup=folium.GeoJsonPopup(fields=popup_fields[:15]),
+                            popup=folium.GeoJsonPopup(fields=popup_fields[:25]),
                             tooltip=folium.GeoJsonTooltip(
                                 fields=[popup_fields[0]],
                                 aliases=[f"{layer_name.title().replace('_', ' ')} ID:"],
                             ),
-                            style_function=lambda x, styling=styling: styling,
-                            highlight_function=lambda x,
-                            highlight_styling=highlight_styling: highlight_styling,
-                            marker=marker_styling,
+                            style_function=lambda x, style=style: style,
+                            highlight_function=lambda x, hl_style=hl_style: hl_style,
+                            marker=marker_style,
                         )
                         if layer_name == "divides" or layer_name == "flowpaths":
                             gdf_fig = folium.FeatureGroup(name=layer_name)
@@ -148,6 +144,32 @@ if subset_submit and submit_valid:
                             gdf_fig = folium.FeatureGroup(name=layer_name, show=False)
                         gdf_fig.add_child(gdf_poly)
                         m.add_child(gdf_fig)
+
+                fp_popup_fields = [c for c in fp_data.columns if c != "geometry"]
+                fp_styling = STYLE_MAP["flowpaths"].get("styling", {})
+                fp_hl_style = STYLE_MAP["flowpaths"].get("highlight_styling", {})
+                three_dim_fp_poly = folium.GeoJson(
+                    data=fp_data,
+                    popup=folium.GeoJsonPopup(
+                        fields=list(fp_popup_fields[:25]),
+                    ),
+                    tooltip=folium.GeoJsonTooltip(
+                        fields=[fp_popup_fields[0], "topwdth", "y_ml"],
+                        aliases=["Reference Flowpath ID:", "Width (ft):", "Depth (ft):"],
+                        localize=True,
+                    ),
+                    style_function=lambda x: fp_styling
+                    | {
+                        "weight": normalize_width(x["properties"]["topwdth"]),
+                        "color": depth_to_gradient(x["properties"]["y_ml"]),
+                        "dashArray": [5, 5] if not x["properties"]["topwdth"] else {},
+                    },
+                    highlight_function=lambda x: fp_hl_style
+                    | {
+                        "weight": normalize_width(x["properties"]["topwdth"]) + 4,
+                    },
+                )
+                m.add_child(folium.FeatureGroup(name="3D Flowpaths", show=False).add_child(three_dim_fp_poly))
 
                 folium.LayerControl(position="bottomright").add_to(m)
                 folium.plugins.Fullscreen(

--- a/app/streamlit/ras_xs_dash.py
+++ b/app/streamlit/ras_xs_dash.py
@@ -82,7 +82,7 @@ if l_col.button("Submit"):
         else:
             # Format and display map
             with st.spinner(text="Generating map..."):
-                xs_map = format_xs_map(catalog, xs_gdf)
+                xs_map = format_xs_map(catalog, xs_gdf, xs_dom)
                 r_col.markdown("#### Map")
                 with r_col:
                     st_folium(fig=xs_map, width=725, returned_objects=[])


### PR DESCRIPTION
Added 3D channel viewing support to streamlit dashboard

## Additions

- Added the option to view the NHF and RAS_XS flowpaths in 3D (width and depth). The width is represented by line width, and the depth by a continuous color gradient (light blue to dark blue).

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
