### PR TITLE
change to check for valid module names and allow processing to contin…

### DIFF
--- a/src/icefabric/modules/get_parameter_metadata.py
+++ b/src/icefabric/modules/get_parameter_metadata.py
@@ -91,44 +91,52 @@ def get_parameter_metadata(
             divide_attrs = pd.DataFrame(gauge["divides"])
 
     output_list = []
+
     for module in modules:
         # Separate query strings to support CFE-S and CFE-X
         if module == "cfe-x":
             query_string = "(module == 'cfe-x' or module == 'cfe') and calibratable == @calibratable"
+            check_module_name = "cfe"
         elif module == "cfe-s":
             query_string = "module == 'cfe' and calibratable == @calibratable"
+            check_module_name = "cfe"
         else:
             query_string = "module == @module and calibratable == @calibratable"
+            check_module_name = module
 
-        module_params = df.query(query_string)[metadata]
+        if df["module"].isin([check_module_name]).any():
+            module_params = df.query(query_string)[metadata]
 
-        # For each parameter, check if the name maps to an NHF or 2.2 divide attribute name,
-        # then compute a basin area weighted average.  If the divide attributes do not exist for the gage,
-        # return the original initial value.
-        if gage_id is not None:
-            parameter_lookup = (
-                ParametersToDivideAttributesNHF.parametersNHF
-                if domain == HydrofabricDomains.NHF
-                else ParametersToDivideAttributesHF.parametersHF
-            )
-            for index, row in module_params.iterrows():
-                param_name = row["name"]
-                if param_name in parameter_lookup.keys():
-                    attr_name = parameter_lookup[param_name]
-                    if attr_name in divide_attrs.columns:
-                        attr = divide_attrs[[attr_name, "area_sqkm"]]
-                        attr = attr[attr[attr_name].notna()]
-                        if len(attr) == 0:
-                            continue
-                        numerator = (attr[attr_name] * attr["area_sqkm"]).sum()
-                        denominator = attr["area_sqkm"].sum()
-                        weighted_avg = numerator / denominator if denominator != 0 else None
-                        module_params.at[index, "initial_value"] = weighted_avg
+            # For each parameter, check if the name maps to an NHF or 2.2 divide attribute name,
+            # then compute a basin area weighted average.  If the divide attributes do not exist for the gage,
+            # return the original initial value.
+            if gage_id is not None:
+                parameter_lookup = (
+                    ParametersToDivideAttributesNHF.parametersNHF
+                    if domain == HydrofabricDomains.NHF
+                    else ParametersToDivideAttributesHF.parametersHF
+                )
+                for index, row in module_params.iterrows():
+                    param_name = row["name"]
+                    if param_name in parameter_lookup.keys():
+                        attr_name = parameter_lookup[param_name]
+                        if attr_name in divide_attrs.columns:
+                            attr = divide_attrs[[attr_name, "area_sqkm"]]
+                            attr = attr[attr[attr_name].notna()]
+                            if len(attr) == 0:
+                                continue
+                            numerator = (attr[attr_name] * attr["area_sqkm"]).sum()
+                            denominator = attr["area_sqkm"].sum()
+                            weighted_avg = numerator / denominator if denominator != 0 else None
+                            module_params.at[index, "initial_value"] = weighted_avg
 
-        # convert dataframe to a list of dictionaries
-        module_params_dict = module_params.to_dict(orient="records")
-        # create dictionary with module name and list of calibratable parameters
-        output = {"module_name": module, "calibratable_parameters": module_params_dict}
+            # convert dataframe to a list of dictionaries
+            module_params_dict = module_params.to_dict(orient="records")
+            # create dictionary with module name and list of calibratablie parameters
+            output = {"module_name": module, "calibratable_parameters": module_params_dict}
+        else:
+            output = {"module_name": module, "error": "Not a valid module name"}
+
         output_list.append(output)
 
     return output_list


### PR DESCRIPTION
##Updates

Add code to check if a module is valid and if not, return an error message.  If there is a list of modules and one is invalid, the valid modules work normally, but the invalid module returns an error message.  The module name in the query is checked against the module names in the iceberg table.  There needed to be some extra consideration for handling CFE where the iceberg table only contains the module name cfe for most parameters (since most are shared between cfe-s and cfe-x) with the parameters exclusive to cfe-x are marked as such.  

In NGWPC-9609, the description says, "The parameter_metadata endpoint is returning a 500 if CFE-X is included in the list of modules".  The problem with CFE-X was fixed in a previous story, however, the code changes in this story add better error handling to the icefabric parameter metadata endpoint.  

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
