### PR TITLE
Add parameter tables to cache catalog

### DIFF
--- a/app/routers/nwm_modules/router.py
+++ b/app/routers/nwm_modules/router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic.json_schema import SkipJsonSchema
 from pyiceberg.catalog import Catalog
 
-from app import get_catalog, get_graphs
+from app import get_cache_catalog, get_cached_namespaces, get_catalog, get_graphs
 from icefabric.modules import SmpModules, config_mapper, get_parameter_metadata
 from icefabric.schemas import GeographicDomain, HydrofabricNamespace, HydrofabricSource
 from icefabric.schemas.modules import (
@@ -818,6 +818,8 @@ async def get_calibratable_parameter_metadata(
         "or legacy values (nhf, conus_hf, etc.) for backwards compatibility.",
     ),
     catalog: Catalog = Depends(get_catalog),
+    cache_catalog: Catalog = Depends(get_cache_catalog),
+    cached_namespaces=Depends(get_cached_namespaces),
     network_graphs=Depends(get_graphs),
 ):
     """
@@ -885,9 +887,12 @@ async def get_calibratable_parameter_metadata(
             formatted_gage_id = f"gages-{gage_id}"
             graph = network_graphs[namespace]
 
+    # Use cache catalog if parameter_metadata namespace is cached
+    active_catalog = cache_catalog if "parameter_metadata" in cached_namespaces else catalog
+
     parameter_metadata = get_parameter_metadata(
         modules=modules,
-        catalog=catalog,
+        catalog=active_catalog,
         gage_id=formatted_gage_id,
         domain=namespace,
         graph=graph,

--- a/docker/compose.test.yaml
+++ b/docker/compose.test.yaml
@@ -1,0 +1,19 @@
+services:
+  myapp:
+    image: icefabric/api
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+    network_mode: "host"
+    environment:
+      - ICEFABRIC_DEPLOY_ENV=${ICEFABRIC_DEPLOY_ENV:-test}
+    env_file:
+      - ../${ICEFABRIC_CREDS_ENV_FILE:-.env}
+    restart: always
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "--head", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 900s


### PR DESCRIPTION
Add parameter tables to cache catalog.

Add a test docker compose file that replicates the docker compose file created by the terraform currently for the Test instance