### PR TITLE
fix subsetter to make sure flowpaths off of origin are included

### DIFF
--- a/src/icefabric/hydrofabric/subset.py
+++ b/src/icefabric/hydrofabric/subset.py
@@ -334,7 +334,7 @@ def subset_hydrofabric(
         print(f"Found origin flowpath: {origin_id}")
         _upstream_ids = get_upstream_segments(origin_id, graph)
         upstream_ids |= _upstream_ids  # in-place union
-        if len(upstream_ids) == 0:
+        if len(_upstream_ids) == 0:
             upstream_ids.add(origin_id)  # Ensuring the origin WB is captured
         else:
             upstream_ids.add(to_id)  # Adding the nexus point to ensure it's captured in the network table


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

The subsetter finds the rows in the network table that contain the hl_uri for the gage that is being subsetted.  In the examples that I looked at these rows correspond to flowpaths that directly flow into the nexus where the gage is located (that is, all have the nexus id corresponding to the gage in the to_id field.  Not all of these flowpaths have upstream ids -- for example, the flowpaths that are missing are singular with nothing upstream.  The code loops through the origin flowpaths and determines if there is anything upstream.  If there is something upstream, it adds those upstream flowpaths to a set.  If the upstream ids for a particular origin flowpath are empty, that flowpath id should be added to the set so that it is included when subsetting the flowpath layer.  In this case, the code was checking the accumulated set of ids which after the first time upstream ids are found won't be empty.  So some origin flowpaths were being missed because the if statement where these flowpaths are added will not be true.  The variable name was corrected to check for the upstream ids corresponding the current origin flowpath and not the accumulated set.  

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
