### PR TITLE
fix: get rid of error responses for lstm and troute

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -89,7 +89,6 @@ parser.add_argument(
     nargs="+",
     help="List of namespaces to include in local cache. Optionally specified as <namespace>:<snapshot>",
     default=[
-        "nhf",
         "conus_nhf",
         "conus_hf",
         "prvi_hf",

--- a/src/icefabric/modules/get_parameter_metadata.py
+++ b/src/icefabric/modules/get_parameter_metadata.py
@@ -104,6 +104,14 @@ def get_parameter_metadata(
             query_string = "module == @module and calibratable == @calibratable"
             check_module_name = module
 
+        # Modules that are valid but don't have parameter metadata yet
+        modules_without_metadata = {"troute", "lstm"}
+
+        if check_module_name in modules_without_metadata:
+            output = {"module_name": module, "calibratable_parameters": []}
+            output_list.append(output)
+            continue
+
         if df["module"].isin([check_module_name]).any():
             module_params = df.query(query_string)[metadata]
 

--- a/tests/smoke/test_parameter_metadata_smoke.py
+++ b/tests/smoke/test_parameter_metadata_smoke.py
@@ -9,8 +9,6 @@ API_BASE_URL = os.environ.get("API_BASE_URL")
 
 pytestmark = pytest.mark.skipif(not API_BASE_URL, reason="API_BASE_URL environment variable not set")
 
-NUMERIC_FIELDS = ["initial_value", "min", "max"]
-
 # All available modules from the endpoint
 ALL_MODULES = [
     "CFE-S",
@@ -29,8 +27,8 @@ ALL_MODULES = [
 ]
 
 
-def test_parameter_metadata_numeric_fields_not_null():
-    """Verify numeric fields are not null in the parameter_metadata response for ALL modules."""
+def test_all_valid_modules_return_no_error():
+    """Verify that all valid modules return without an error message."""
     modules_param = "&".join([f"modules={m}" for m in ALL_MODULES])
     url = f"{API_BASE_URL}/v1/modules/parameter_metadata/?{modules_param}"
 
@@ -40,39 +38,29 @@ def test_parameter_metadata_numeric_fields_not_null():
     data = response.json()
     assert "modules" in data
 
-    violations = []
+    errors = []
     for module in data["modules"]:
         module_name = module.get("module_name", "UNKNOWN")
-        for param in module.get("calibratable_parameters", []):
-            param_name = param.get("name", "UNKNOWN")
-            for field in NUMERIC_FIELDS:
-                if param.get(field) is None:
-                    violations.append(f"Module '{module_name}', Parameter '{param_name}': '{field}' is null")
+        if "error" in module:
+            errors.append(f"Module '{module_name}': {module['error']}")
 
-    assert len(violations) == 0, f"Found {len(violations)} null numeric field(s):\n" + "\n".join(violations)
+    assert len(errors) == 0, f"Found {len(errors)} module error(s):\n" + "\n".join(errors)
 
 
-def test_gage_specific_parameter_metadata_numeric_fields_not_null():
-    """Verify numeric fields are not null when querying with domain and gage_id."""
-    modules_param = "&".join([f"modules={m}" for m in ALL_MODULES])
-    url = f"{API_BASE_URL}/v1/modules/parameter_metadata/?{modules_param}&domain=CONUS&gage_id=01123000"
+def test_invalid_module_returns_error():
+    """Verify that a bogus module name returns an error message."""
+    url = f"{API_BASE_URL}/v1/modules/parameter_metadata/?modules=bogus_module"
 
     response = requests.get(url, timeout=30)
     assert response.status_code == 200, f"Request failed: {response.status_code}"
 
     data = response.json()
     assert "modules" in data
+    assert len(data["modules"]) == 1
 
-    violations = []
-    for module in data["modules"]:
-        module_name = module.get("module_name", "UNKNOWN")
-        for param in module.get("calibratable_parameters", []):
-            param_name = param.get("name", "UNKNOWN")
-            for field in NUMERIC_FIELDS:
-                if param.get(field) is None:
-                    violations.append(f"Module '{module_name}', Parameter '{param_name}': '{field}' is null")
-
-    assert len(violations) == 0, f"Found {len(violations)} null numeric field(s):\n" + "\n".join(violations)
+    module = data["modules"][0]
+    assert "error" in module, "Expected an error for invalid module name"
+    assert module["module_name"] == "bogus_module"
 
 
 def test_api_health():


### PR DESCRIPTION
Made it so that LSTM and T-Route module requests don't return an error.

Modified smoke tests to ensure that all valid modules don't return an error.

Removed nhf table from being cached since no route activates the local nhf table. nhf_conus is still being cached and can be activated.