### PR TITLE
NGWPC-9460 - Add Streamflow Observation hydrograph generation to dashboard

### DIFF
--- a/app/routers/streamflow_observations/router.py
+++ b/app/routers/streamflow_observations/router.py
@@ -6,7 +6,6 @@ from datetime import datetime
 import icechunk
 import numpy as np
 import xarray as xr
-from botocore.exceptions import ClientError
 from fastapi import APIRouter, HTTPException, Path, Query
 from fastapi.background import BackgroundTasks
 from fastapi.responses import FileResponse
@@ -100,15 +99,18 @@ def get_data_and_repo_hist():
         repo = icechunk.Repository.open(storage_config)
         session = repo.writable_session("main")
         ds = xr.open_zarr(session.store, consolidated=False)
-    except ClientError as e:
-        msg = "AWS Test account credentials expired. Can't access remote S3 Table"
-        raise ClientError(msg) from e
+    except icechunk.IcechunkError as e:
+        msg = "AWS credentials are expired or incorrect."
+        raise PermissionError(msg) from e
     return ds, repo
 
 
 def validate_identifier(identifier: str):
     """Check if identifier exists in the dataset"""
-    ds, repo = get_data_and_repo_hist()
+    try:
+        ds, repo = get_data_and_repo_hist()
+    except PermissionError as e:
+        raise PermissionError(f"Cannot access S3 storage - {e}") from e
     if identifier not in ds.coords["id"]:
         raise HTTPException(
             status_code=404,

--- a/app/streamlit/hydrofabric_dash.py
+++ b/app/streamlit/hydrofabric_dash.py
@@ -18,7 +18,7 @@ from app.streamlit.tooltips import hf_subset_options_explanation
 from icefabric.cli.streamflow import NoResultsFoundError
 from icefabric.hydrofabric import subset_nhf
 
-st.session_state.NHF_SUBSET_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+st.session_state.TEMP_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 catalog = st.session_state.catalog
 
@@ -50,7 +50,8 @@ with r_col.form("Subset"):
 
 if subset_submit and submit_valid:
     subset_gpkg_file = (
-        st.session_state.NHF_SUBSET_OUTPUT_DIR
+        st.session_state.TEMP_OUTPUT_DIR
+        / "nhf_subset_gpkg_files"
         / f"nhf_subset_by_{subset_type.replace(' ', '_').lower()}_{subset_user_sel}.gpkg"
     )
     subset_successful = False

--- a/app/streamlit/sf_obsv_dash.py
+++ b/app/streamlit/sf_obsv_dash.py
@@ -1,0 +1,202 @@
+import os
+
+import altair as alt
+import folium
+import geopandas as gpd
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import polars as pl
+import streamlit as st
+from matplotlib.dates import DateFormatter
+from streamlit_folium import st_folium
+
+from app.routers.streamflow_observations.router import get_data_and_repo_hist as get_all_sf_obsv
+from app.routers.streamflow_observations.router import validate_identifier as get_sf_obsv
+from app.streamlit.helpers import (
+    STYLE_MAP,
+)
+from icefabric.hydrofabric.subset_nhf import (
+    HydrofabricSource,
+    resolve_gage_to_flowpath,
+)
+
+
+@st.fragment
+def create_overall_sf_chart(df, gage_id_user_sel):
+    """Creates/saves/displays overall discharge hydrograph for given gage ID selection."""
+    sf_discharge_path = (
+        st.session_state.TEMP_OUTPUT_DIR
+        / "sf_obsv_discharge_hydrographs"
+        / f"sf_discharge_{gage_id_user_sel}.jpeg"
+    )
+    sf_discharge_path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(16, 6))
+    ax.plot(df["time"], df["q_cms"], label="Discharge", color="blue")
+    ax.set_title(f"Discharge Hydrograph of {gage_id_user_sel}")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Discharge (cms)")
+    ax.legend(loc="best", edgecolor="k")
+    ax.xaxis.set_major_formatter(DateFormatter("%b %Y"))
+    plt.setp(ax.xaxis.get_majorticklabels(), rotation=45)
+    plt.tight_layout()
+    plt.savefig(os.path.join(os.getcwd(), sf_discharge_path))
+    plt.close(fig)
+
+    st.image(os.path.join(os.getcwd(), sf_discharge_path), caption="Discharge Hydrograph")
+
+
+@st.fragment
+def show_sf_data(df, gage_id_user_sel):
+    """Creates and displays the streamflow observations dataframe and overall hydrograph for a given gage ID selection."""
+    with st.expander(label="Full Results", expanded=True):
+        l_col, r_col = st.columns([2, 3], gap="small")
+        df = ds.sel(id=gage_id_user_sel).to_dataframe().reset_index()
+        df.dropna(subset=["q_cms"], inplace=True)
+        l_col.markdown(f"### Streamflow Observations for Gage ID `{gage_id_user_sel}`")
+        df = df[df["q_cms"] >= 0]
+        df.drop(columns=["id"], inplace=True)
+        l_col.dataframe(df, hide_index=True, width=700)
+        with r_col:
+            create_overall_sf_chart(df, gage_id_user_sel)
+
+    with st.expander(label="Interactive Subset", expanded=True):
+        year_sel, month_sel, time_disp_string = None, None, None
+        sf_years_available = np.unique(df["time"].dt.year).tolist()
+        year_sel = st.pills(
+            label="__Available Years__",
+            options=sf_years_available,
+            selection_mode="single",
+            help="Select a year to view the streamflow hydrograph for that year.",
+        )
+        if year_sel:
+            year_max = df[df["time"].dt.year == year_sel]["q_cms"].max()
+            sf_months_available = np.unique(df[df["time"].dt.year == year_sel]["time"].dt.month).tolist()
+            month_sel = st.pills(
+                label="__Available Months__",
+                options=sf_months_available,
+                selection_mode="single",
+                help="Select a month to view the streamflow hydrograph for that year & month.",
+            )
+            if month_sel:
+                df_subset = df[(df["time"].dt.year == year_sel) & (df["time"].dt.month == month_sel)]
+                start_of_month = f"{year_sel}-{str(month_sel).zfill(2)}"
+                if month_sel == 12:
+                    end_of_month = f"{year_sel + 1}-01-01 00:00:00"
+                else:
+                    end_of_month = f"{year_sel}-{str(month_sel + 1).zfill(2)}"
+                all_hours = pd.date_range(start=start_of_month, end=end_of_month, freq="h")[:-1]
+                time_disp_string = f"{year_sel}-{str(month_sel).zfill(2)}"
+            else:
+                df_subset = df[df["time"].dt.year == year_sel]
+                all_hours = pd.date_range(start=str(year_sel), end=str(year_sel + 1), freq="h")[:-1]
+                time_disp_string = f"{year_sel}"
+            df_subset = df_subset.set_index("time").reindex(all_hours).reset_index(names="time")
+            st.markdown(f"### Hourly Discharge Hydrograph (Gage `{gage_id_user_sel}` - {time_disp_string})")
+            chart = (
+                alt.Chart(df_subset)
+                .mark_line(
+                    point=True,
+                )
+                .encode(
+                    x=alt.X("time:T", title="Time"),
+                    y=alt.Y("q_cms:Q", title="Discharge (m³/s)", scale=alt.Scale(domain=[0, year_max * 1.1])),
+                    tooltip=[
+                        alt.Tooltip("time:T", title="Time", format="%Y-%m-%d %H:%M"),
+                        alt.Tooltip("q_cms:Q", title="Discharge (m³/s)"),
+                    ],
+                )
+                .properties(height=750, width=1500)
+            ).interactive()
+            st.altair_chart(chart)
+
+
+@st.fragment
+def show_sf_map(gage_id_user_sel):
+    """Show flowpath map of gage location."""
+    nhf_flowpath_id = resolve_gage_to_flowpath(nhf_source, gage_id_user_sel)
+
+    fp_df = (
+        catalog.load_table("nhf.flowpaths").to_polars().filter(pl.col("fp_id") == nhf_flowpath_id).collect()
+    )
+    fp_id, div_id = fp_df["fp_id"][0], fp_df["div_id"][0]
+    dv_df = catalog.load_table("nhf.divides").to_polars().filter(pl.col("div_id") == div_id).collect()
+    st.markdown(f"### Map of Gage `{gage_id_user_sel}` Location (maps to flowpath ID `{fp_id}`)")
+
+    fp_gdf = gpd.GeoDataFrame(
+        fp_df,
+        columns=fp_df.columns,
+        geometry=gpd.GeoSeries.from_wkb(fp_df["geometry"]),
+        crs="EPSG:5070",
+    ).to_crs(epsg=4326)
+    dv_gdf = gpd.GeoDataFrame(
+        dv_df,
+        columns=dv_df.columns,
+        geometry=gpd.GeoSeries.from_wkb(dv_df["geometry"]),
+        crs="EPSG:5070",
+    ).to_crs(epsg=4326)
+
+    m = folium.Map(tiles=folium.TileLayer(tiles="Cartodb Positron", control=False))
+    minx, miny, maxx, maxy = dv_gdf.bounds.values.tolist()[0]
+    m.fit_bounds([[miny, minx], [maxy, maxx]])
+
+    fp_df_fig = folium.FeatureGroup(name="Flowpath")
+    dv_gdf_fig = folium.FeatureGroup(name="Divide")
+    fp_poly = folium.GeoJson(
+        data=fp_gdf,
+        style_function=lambda x, style=STYLE_MAP["flowpaths"]["styling"]: style,
+    )
+    dv_poly = folium.GeoJson(
+        data=dv_gdf,
+        style_function=lambda x, style=STYLE_MAP["divides"]["styling"]: style,
+    )
+    m.add_child(dv_gdf_fig.add_child(dv_poly))
+    m.add_child(fp_df_fig.add_child(fp_poly))
+
+    folium.LayerControl(position="bottomright").add_to(m)
+    folium.plugins.Fullscreen(
+        position="topright",
+        title="Expand me",
+        title_cancel="Exit me",
+        force_separate_button=True,
+    ).add_to(m)
+
+    st_folium(fig=m, width=770, returned_objects=[])
+
+
+st.session_state.TEMP_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+st.set_page_config(page_title="Streamflow Observations", layout="wide")
+st.title("Streamflow Observations")
+st.write("Please select a gage ID to view the streamflow observations and corresponding hydrograph.")
+
+
+catalog = st.session_state.catalog
+nhf_source = HydrofabricSource(parquet_dir=None, catalog=catalog)
+# Get list of gage IDs for dropdown selection
+try:
+    sf_obsv_ds, _ = get_all_sf_obsv()
+    ids = np.unique(sf_obsv_ds.coords["id"]).tolist()
+except PermissionError as e:
+    st.error(f"{e}", icon=":material/error:")
+
+with st.form("Select Gage", width=300):
+    st.markdown("#### __Gage Selection__")
+    ds = None
+    gage_id_user_sel = st.selectbox(
+        label="__ID__", options=ids, help="Select a gage ID to view its streamflow observations."
+    )
+    sel_submit = st.form_submit_button("Submit")
+    if sel_submit:
+        try:
+            ds, _ = get_sf_obsv(gage_id_user_sel)
+        except PermissionError as e:
+            st.error(f"{e}", icon=":material/error:")
+        df = ds.sel(id=gage_id_user_sel).to_dataframe().reset_index()
+        df.dropna(subset=["q_cms"], inplace=True)
+
+if sel_submit and ds:
+    show_sf_data(df, gage_id_user_sel)
+
+    with st.expander(label="Gage Map", expanded=True, width=800):
+        show_sf_map(gage_id_user_sel)

--- a/app/streamlit/streamlit.py
+++ b/app/streamlit/streamlit.py
@@ -52,6 +52,7 @@ modules = {
     "Modules": [
         st.Page("hydrofabric_dash.py", title="NGWPC Hydrofabric", icon=":material/water_drop:"),
         st.Page("ras_xs_dash.py", title="RAS XS", icon=":material/arrow_range:"),
+        st.Page("sf_obsv_dash.py", title="Streamflow Observations", icon=":material/waves:"),
     ],
 }
 
@@ -62,16 +63,17 @@ st.set_page_config(
 
 # Cleanup temp files on app start
 if "initialized" not in st.session_state or not st.session_state.initialized:
-    if "NHF_SUBSET_OUTPUT_DIR" not in st.session_state:
-        st.session_state["NHF_SUBSET_OUTPUT_DIR"] = (
-            pathlib.Path(tempfile.gettempdir()) / "icefabric_streamlit_subsets"
+    if "TEMP_OUTPUT_DIR" not in st.session_state:
+        st.session_state["TEMP_OUTPUT_DIR"] = (
+            pathlib.Path(tempfile.gettempdir()) / "icefabric_streamlit_tmp_files"
         )
-    st.session_state.NHF_SUBSET_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    for item in st.session_state.NHF_SUBSET_OUTPUT_DIR.iterdir():
-        if item.is_dir():
-            item.rmdir(missing_ok=True)
-        else:
-            item.unlink(missing_ok=True)
+    st.session_state.TEMP_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    for dir in st.session_state.TEMP_OUTPUT_DIR.iterdir():
+        for item in dir.iterdir():
+            if item.is_dir():
+                pass
+            else:
+                item.unlink(missing_ok=True)
     st.session_state.initialized = True
 
 pg = st.navigation(modules)


### PR DESCRIPTION
Add Streamflow Observation hydrograph/mapping page to dashboard

## Additions

- Added a new page to the dashboard for streamflow observations. User can input a gage ID and get the results back as a dataframe and as a discharge hydrograph. Further, the user can view individual years interactively, as well as months within a year. Finally, a map of the flowpath/divide that maps to that gage ID is shown.