### PR TITLE
Ngpwc 9824 site no to hl uri

### DIFF
--- a/app/routers/hydrofabric/router.py
+++ b/app/routers/hydrofabric/router.py
@@ -220,7 +220,8 @@ async def get_hydrofabric_subset_gpkg(
         if not tmp_path.is_file():
             raise HTTPException(status_code=500, detail="Expected file but got directory")
 
-        logger.info(f"Successfully created geopackage: {tmp_path} (size: {tmp_path.stat().st_size} bytes)")
+        filesize = tmp_path.stat().st_size
+        logger.info(f"Successfully created geopackage: {tmp_path} (size: {filesize} bytes)")
 
         # Create download filename
         safe_identifier = identifier.replace("/", "_").replace("\\", "_")

--- a/app/routers/hydrofabric/router.py
+++ b/app/routers/hydrofabric/router.py
@@ -1,4 +1,3 @@
-import logging
 import pathlib
 import sqlite3
 import tempfile
@@ -34,9 +33,6 @@ from icefabric.schemas.hydrofabric import (
     IdType,
     QueryIdType,
 )
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 api_router = APIRouter(prefix="/hydrofabric")
 
@@ -186,13 +182,13 @@ async def get_hydrofabric_subset_gpkg(
                 else:
                     nonspatial_layers[table_name] = layer_data
             else:
-                logger.warning(f"Warning: {table_name} layer is empty")
+                print(f"Warning: {table_name} layer is empty")
 
         # Write spatial layers first with pyogrio
         for table_name, layer_data in spatial_layers.items():
             pyogrio.write_dataframe(layer_data, tmp_path, layer=table_name)
             layers_written += 1
-            logger.info(f"Written spatial layer '{table_name}' with {len(layer_data)} records")
+            print(f"Written spatial layer '{table_name}' with {len(layer_data)} records")
 
         # Then write non-spatial layers with sqlite3
         if nonspatial_layers:
@@ -200,7 +196,7 @@ async def get_hydrofabric_subset_gpkg(
             for table_name, layer_data in nonspatial_layers.items():
                 layer_data.to_sql(table_name, conn, if_exists="replace", index=False)
                 layers_written += 1
-                logger.info(f"Written non-spatial layer '{table_name}' with {len(layer_data)} records")
+                print(f"Written non-spatial layer '{table_name}' with {len(layer_data)} records")
             conn.close()
 
             if layers_written == 0:
@@ -221,7 +217,7 @@ async def get_hydrofabric_subset_gpkg(
             raise HTTPException(status_code=500, detail="Expected file but got directory")
 
         filesize = tmp_path.stat().st_size
-        logger.info(f"Successfully created geopackage: {tmp_path} (size: {filesize} bytes)")
+        print(f"Successfully created geopackage: {tmp_path} (size: {filesize} bytes)")
 
         # Create download filename
         safe_identifier = identifier.replace("/", "_").replace("\\", "_")

--- a/app/routers/hydrofabric/router.py
+++ b/app/routers/hydrofabric/router.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 import sqlite3
 import tempfile
@@ -33,6 +34,9 @@ from icefabric.schemas.hydrofabric import (
     IdType,
     QueryIdType,
 )
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 api_router = APIRouter(prefix="/hydrofabric")
 
@@ -87,7 +91,7 @@ async def get_hydrofabric_subset_gpkg(
 
     **Parameters:**
     - **identifier**: The unique identifier to start tracing from
-    - **id_type**: Type of identifier (hl_uri, id, poi_id)
+    - **id_type**: Type of identifier (gage_id, flowpath_id, vpu_id)
     - **domain**: Hydrofabric domain/namespace to query
     - **layers**: Additional layers to include (core layers always included)
 
@@ -182,13 +186,13 @@ async def get_hydrofabric_subset_gpkg(
                 else:
                     nonspatial_layers[table_name] = layer_data
             else:
-                print(f"Warning: {table_name} layer is empty")
+                logger.warning(f"Warning: {table_name} layer is empty")
 
         # Write spatial layers first with pyogrio
         for table_name, layer_data in spatial_layers.items():
             pyogrio.write_dataframe(layer_data, tmp_path, layer=table_name)
             layers_written += 1
-            print(f"Written spatial layer '{table_name}' with {len(layer_data)} records")
+            logger.info(f"Written spatial layer '{table_name}' with {len(layer_data)} records")
 
         # Then write non-spatial layers with sqlite3
         if nonspatial_layers:
@@ -196,7 +200,7 @@ async def get_hydrofabric_subset_gpkg(
             for table_name, layer_data in nonspatial_layers.items():
                 layer_data.to_sql(table_name, conn, if_exists="replace", index=False)
                 layers_written += 1
-                print(f"Written non-spatial layer '{table_name}' with {len(layer_data)} records")
+                logger.info(f"Written non-spatial layer '{table_name}' with {len(layer_data)} records")
             conn.close()
 
             if layers_written == 0:
@@ -216,7 +220,7 @@ async def get_hydrofabric_subset_gpkg(
         if not tmp_path.is_file():
             raise HTTPException(status_code=500, detail="Expected file but got directory")
 
-        print(f"Successfully created geopackage: {tmp_path} (size: {tmp_path.stat().st_size} bytes)")
+        logger.info(f"Successfully created geopackage: {tmp_path} (size: {tmp_path.stat().st_size} bytes)")
 
         # Create download filename
         safe_identifier = identifier.replace("/", "_").replace("\\", "_")

--- a/app/routers/hydrofabric/router.py
+++ b/app/routers/hydrofabric/router.py
@@ -31,7 +31,7 @@ from icefabric.schemas.hydrofabric import (
     HydrofabricNamespace,
     HydrofabricSource,
     IdType,
-    QueryIdType
+    QueryIdType,
 )
 
 api_router = APIRouter(prefix="/hydrofabric")
@@ -43,20 +43,20 @@ async def get_hydrofabric_subset_gpkg(
         ...,
         description="Identifier to start tracing from (e.g., catchment ID, POI ID, HL_URI)",
         openapi_examples={
-            "fp_id": {"summary": "NHF Flowpath ID (NHF)", "value": 3490271},
+            "NHF flowpath": {"summary": "NHF Flowpath ID (NHF)", "value": 3490271},
             "vpu-id": {"summary": "VPU ID (NHF)", "value": "01"},
-            "hl_uri": {"summary": "USGS Gauge ID (HFv2.2, NHF)", "value": "01010000"},
-            "wb-id": {"summary": "Watershed ID (HFv2.2)", "value": "wb-4581"},
+            "gage id": {"summary": "USGS Gauge ID (HFv2.2, NHF)", "value": "01010000"},
+            "2.2 flowpath": {"summary": "Watershed ID (HFv2.2)", "value": "wb-4581"},
         },
     ),
     id_type: QueryIdType = Query(
         ...,
         description="The type of identifier being used",
         openapi_examples={
-            "fp_id": {"summary": "NHF Flowpath ID (NHF)", "value": IdType.FP_ID},
-            "vpu-id": {"summary": "VPU ID (NHF)", "value": IdType.VPU_ID},
-            "hl_uri": {"summary": "USGS Gauge (HFv2.2, NHF)", "value": IdType.HL_URI},
-            "wb-id": {"summary": "Watershed ID (HFv2.2)", "value": IdType.ID},
+            "NHF flowpath": {"summary": "NHF Flowpath ID (NHF)", "value": QueryIdType.FLOWPATH_ID},
+            "vpu-id": {"summary": "VPU ID (NHF)", "value": QueryIdType.VPU_ID},
+            "gage id": {"summary": "USGS Gauge (HFv2.2, NHF)", "value": QueryIdType.GAGE_ID},
+            "2.2 flowpath": {"summary": "Watershed ID (HFv2.2)", "value": QueryIdType.FLOWPATH_ID},
         },
     ),
     source: HydrofabricSource | SkipJsonSchema[None] = Query(
@@ -144,7 +144,7 @@ async def get_hydrofabric_subset_gpkg(
                 output_layers = subset_hydrofabric(
                     catalog=catalog,
                     identifier=f"gages-{identifier}",
-                    id_type=IdType.HL_URI.value,
+                    id_type=IdType.HL_URI,
                     layers=layers or ["divides", "flowpaths", "network", "nexus"],
                     namespace=namespace,
                     graph=network_graphs[namespace],
@@ -153,7 +153,7 @@ async def get_hydrofabric_subset_gpkg(
                 output_layers = subset_hydrofabric(
                     catalog=catalog,
                     identifier=identifier,
-                    id_type=IdType.ID.value,
+                    id_type=IdType.ID,
                     layers=layers or ["divides", "flowpaths", "network", "nexus"],
                     namespace=namespace,
                     graph=network_graphs[namespace],

--- a/app/routers/hydrofabric/router.py
+++ b/app/routers/hydrofabric/router.py
@@ -216,8 +216,7 @@ async def get_hydrofabric_subset_gpkg(
         if not tmp_path.is_file():
             raise HTTPException(status_code=500, detail="Expected file but got directory")
 
-        filesize = tmp_path.stat().st_size
-        print(f"Successfully created geopackage: {tmp_path} (size: {filesize} bytes)")
+        print(f"Successfully created geopackage: {tmp_path} (size: {tmp_path.stat().st_size} bytes)")
 
         # Create download filename
         safe_identifier = identifier.replace("/", "_").replace("\\", "_")

--- a/app/routers/hydrofabric/router.py
+++ b/app/routers/hydrofabric/router.py
@@ -31,6 +31,7 @@ from icefabric.schemas.hydrofabric import (
     HydrofabricNamespace,
     HydrofabricSource,
     IdType,
+    QueryIdType
 )
 
 api_router = APIRouter(prefix="/hydrofabric")
@@ -48,7 +49,7 @@ async def get_hydrofabric_subset_gpkg(
             "wb-id": {"summary": "Watershed ID (HFv2.2)", "value": "wb-4581"},
         },
     ),
-    id_type: IdType = Query(
+    id_type: QueryIdType = Query(
         ...,
         description="The type of identifier being used",
         openapi_examples={
@@ -118,17 +119,17 @@ async def get_hydrofabric_subset_gpkg(
 
     try:
         if namespace.is_nhf:
-            if id_type == IdType.VPU_ID:
+            if id_type == QueryIdType.VPU_ID:
                 output_layers = subset_nhf(
                     vpu_id=identifier,
                     catalog=catalog,
                 )
-            elif id_type == IdType.FP_ID:
+            elif id_type == QueryIdType.FLOWPATH_ID:
                 output_layers = subset_nhf(
                     flowpath_id=int(identifier),
                     catalog=catalog,
                 )
-            elif id_type == IdType.HL_URI:
+            elif id_type == QueryIdType.GAGE_ID:
                 output_layers = subset_nhf(
                     gage_id=identifier,
                     catalog=catalog,
@@ -136,14 +137,20 @@ async def get_hydrofabric_subset_gpkg(
             else:
                 raise ValueError(f"Incorrect ID type: {id_type} for the NHF")
         else:
-            if id_type in [
-                IdType.HL_URI,
-                IdType.ID,
-            ]:
+            if id_type == QueryIdType.GAGE_ID:
                 output_layers = subset_hydrofabric(
                     catalog=catalog,
                     identifier=f"gages-{identifier}",
-                    id_type=id_type,
+                    id_type=IdType.HL_URI.value,
+                    layers=layers or ["divides", "flowpaths", "network", "nexus"],
+                    namespace=namespace,
+                    graph=network_graphs[namespace],
+                )
+            elif id_type == QueryIdType.FLOWPATH_ID:
+                output_layers = subset_hydrofabric(
+                    catalog=catalog,
+                    identifier=identifier,
+                    id_type=IdType.ID.value,
                     layers=layers or ["divides", "flowpaths", "network", "nexus"],
                     namespace=namespace,
                     graph=network_graphs[namespace],

--- a/app/routers/hydrofabric/router.py
+++ b/app/routers/hydrofabric/router.py
@@ -43,9 +43,9 @@ async def get_hydrofabric_subset_gpkg(
         description="Identifier to start tracing from (e.g., catchment ID, POI ID, HL_URI)",
         openapi_examples={
             "fp_id": {"summary": "NHF Flowpath ID (NHF)", "value": 3490271},
-            "site-no": {"summary": "UGSG Site no (NHF)", "value": "02374250"},
+            #"site-no": {"summary": "UGSG Site no (NHF)", "value": "02374250"},
             "vpu-id": {"summary": "VPU ID (NHF)", "value": "01"},
-            "hl_uri": {"summary": "USGS Gauge (HFv2.2)", "value": "gages-01010000"},
+            "hl_uri": {"summary": "USGS Gauge ID (HFv2.2, NHF)", "value": "01010000"},
             "wb-id": {"summary": "Watershed ID (HFv2.2)", "value": "wb-4581"},
         },
     ),
@@ -55,7 +55,7 @@ async def get_hydrofabric_subset_gpkg(
         openapi_examples={
             "fp_id": {"summary": "NHF Flowpath ID (NHF)", "value": IdType.FP_ID},
             "vpu-id": {"summary": "VPU ID (NHF)", "value": IdType.VPU_ID},
-            "site-no": {"summary": "UGSG Site no (NHF)", "value": IdType.SITE_NO},
+            #"site-no": {"summary": "UGSG Site no (NHF)", "value": IdType.SITE_NO},
             "hl_uri": {"summary": "USGS Gauge (HFv2.2, NHF)", "value": IdType.HL_URI},
             "wb-id": {"summary": "Watershed ID (HFv2.2)", "value": IdType.ID},
         },
@@ -130,7 +130,7 @@ async def get_hydrofabric_subset_gpkg(
                     flowpath_id=int(identifier),
                     catalog=catalog,
                 )
-            elif id_type == IdType.SITE_NO:
+            elif id_type == IdType.HL_URI:
                 output_layers = subset_nhf(
                     gage_id=identifier,
                     catalog=catalog,
@@ -144,7 +144,7 @@ async def get_hydrofabric_subset_gpkg(
             ]:
                 output_layers = subset_hydrofabric(
                     catalog=catalog,
-                    identifier=identifier,
+                    identifier=f"gages-{identifier}",
                     id_type=id_type,
                     layers=layers or ["divides", "flowpaths", "network", "nexus"],
                     namespace=namespace,

--- a/app/routers/hydrofabric/router.py
+++ b/app/routers/hydrofabric/router.py
@@ -43,7 +43,6 @@ async def get_hydrofabric_subset_gpkg(
         description="Identifier to start tracing from (e.g., catchment ID, POI ID, HL_URI)",
         openapi_examples={
             "fp_id": {"summary": "NHF Flowpath ID (NHF)", "value": 3490271},
-            #"site-no": {"summary": "UGSG Site no (NHF)", "value": "02374250"},
             "vpu-id": {"summary": "VPU ID (NHF)", "value": "01"},
             "hl_uri": {"summary": "USGS Gauge ID (HFv2.2, NHF)", "value": "01010000"},
             "wb-id": {"summary": "Watershed ID (HFv2.2)", "value": "wb-4581"},
@@ -55,7 +54,6 @@ async def get_hydrofabric_subset_gpkg(
         openapi_examples={
             "fp_id": {"summary": "NHF Flowpath ID (NHF)", "value": IdType.FP_ID},
             "vpu-id": {"summary": "VPU ID (NHF)", "value": IdType.VPU_ID},
-            #"site-no": {"summary": "UGSG Site no (NHF)", "value": IdType.SITE_NO},
             "hl_uri": {"summary": "USGS Gauge (HFv2.2, NHF)", "value": IdType.HL_URI},
             "wb-id": {"summary": "Watershed ID (HFv2.2)", "value": IdType.ID},
         },

--- a/src/icefabric/schemas/hydrofabric.py
+++ b/src/icefabric/schemas/hydrofabric.py
@@ -82,6 +82,23 @@ class IdType(str, Enum):
     VPU_ID = "vpu_id"
     FP_ID = ("fp_id",)
 
+class QueryIdType(str, Enum):
+    """All query types for the API.
+
+    Attributes
+    ----------
+    GAGE_ID : str
+        Gage ID query identifier
+    FLOWPATH_ID : str
+        Flowpath ID query identifier
+    VPU_ID : str
+         VPU ID query identifier
+    """
+
+    GAGE_ID = "gage_id"
+    FLOWPATH_ID = "flowpath_id"
+    VPU_ID = "vpu_id"
+
 
 class StreamflowDataSources(str, Enum):
     """The data sources used for hourly streamflow data"""

--- a/src/icefabric/schemas/hydrofabric.py
+++ b/src/icefabric/schemas/hydrofabric.py
@@ -81,7 +81,6 @@ class IdType(str, Enum):
     POI_ID = "poi_id"
     VPU_ID = "vpu_id"
     FP_ID = ("fp_id",)
-    SITE_NO = "site_no"
 
 
 class StreamflowDataSources(str, Enum):

--- a/src/icefabric/schemas/hydrofabric.py
+++ b/src/icefabric/schemas/hydrofabric.py
@@ -75,12 +75,14 @@ class IdType(str, Enum):
         Point of Interest ID identifier
     """
 
-    HL_URI = "hl_uri"
-    HF_ID = "hf_id"
-    ID = "id"
-    POI_ID = "poi_id"
+    HL_URI = "hl_uri"  # HF 2.2 only
+    HF_ID = "hf_id"  # HF 2.2 only
+    ID = "id"  # HF 2.2 only
+    POI_ID = "poi_id"  # HF 2.2 only
     VPU_ID = "vpu_id"
-    FP_ID = ("fp_id",)
+    FP_ID = "fp_id"
+    SITE_NO = "site_no"
+
 
 class QueryIdType(str, Enum):
     """All query types for the API.

--- a/src/icefabric/schemas/hydrofabric.py
+++ b/src/icefabric/schemas/hydrofabric.py
@@ -73,7 +73,8 @@ class IdType(str, Enum):
 
     HL_URI = "hl_uri"  # HF 2.2 only
     ID = "id"  # HF 2.2 only
-    POI_ID = "poi_id" # HF 2.2 only
+    POI_ID = "poi_id"  # HF 2.2 only
+
 
 class QueryIdType(str, Enum):
     """All query types for the API.

--- a/src/icefabric/schemas/hydrofabric.py
+++ b/src/icefabric/schemas/hydrofabric.py
@@ -67,22 +67,13 @@ class IdType(str, Enum):
     ----------
     HL_URI : str
         Hydrolocation URI identifier
-    HF_ID : str
-        Hydrofabric ID identifier
     ID : str
         Generic ID identifier
-    POI_ID : str
-        Point of Interest ID identifier
     """
 
     HL_URI = "hl_uri"  # HF 2.2 only
-    HF_ID = "hf_id"  # HF 2.2 only
     ID = "id"  # HF 2.2 only
-    POI_ID = "poi_id"  # HF 2.2 only
-    VPU_ID = "vpu_id"
-    FP_ID = "fp_id"
-    SITE_NO = "site_no"
-
+    POI_ID = "poi_id" # HF 2.2 only
 
 class QueryIdType(str, Enum):
     """All query types for the API.

--- a/tests/app/test_hydrofabric_router.py
+++ b/tests/app/test_hydrofabric_router.py
@@ -5,7 +5,7 @@ import pytest
 def test_subset_hl_uri_good(client, watershed_bound_id_good: str):
     """Test: /v1/hydrofabric/{gauge_hf_uri_good}/gpkg"""
     response = client.get(
-        f"/v1/hydrofabric/{watershed_bound_id_good}/gpkg?id_type=id&domain=hi_hf&layers=divides&layers=flowpaths&layers=network&layers=nexus"
+        f"/v1/hydrofabric/{watershed_bound_id_good}/gpkg?id_type=flowpath_id&domain=hi_hf&layers=divides&layers=flowpaths&layers=network&layers=nexus"
     )
     assert response.status_code == 200, f"Request failed with status {response.status_code}: {response.text}"
 
@@ -14,7 +14,7 @@ def test_subset_hl_uri_good(client, watershed_bound_id_good: str):
 def test_subset_hl_uri_bad(client, watershed_bound_id_bad: str):
     """Test: /v1/hydrofabric/{gauge_hf_uri_bad}/gpkg"""
     response = client.get(
-        f"/v1/hydrofabric/{watershed_bound_id_bad}/gpkg?id_type=id&domain=hi_hf&layers=divides&layers=flowpaths&layers=network&layers=nexus"
+        f"/v1/hydrofabric/{watershed_bound_id_bad}/gpkg?id_type=flowpath_id&domain=hi_hf&layers=divides&layers=flowpaths&layers=network&layers=nexus"
     )
     assert response.status_code == 404, (
         f"Request did not fail as expected. Status: {response.status_code}: {response.text}"

--- a/tests/app/test_source_parameter.py
+++ b/tests/app/test_source_parameter.py
@@ -231,7 +231,7 @@ class TestHydrofabricRouterSourceParameter:
         """Test hydrofabric endpoint with legacy hi_hf domain still works."""
         response = client.get(
             f"/v1/hydrofabric/{watershed_bound_id_good}/gpkg"
-            "?id_type=id&domain=hi_hf&layers=divides&layers=flowpaths&layers=network&layers=nexus"
+            "?id_type=flowpath_id&domain=hi_hf&layers=divides&layers=flowpaths&layers=network&layers=nexus"
         )
         assert response.status_code == 200
 
@@ -243,14 +243,14 @@ class TestHydrofabricRouterSourceParameter:
         """
         response = client.get(
             f"/v1/hydrofabric/{watershed_bound_id_good}/gpkg"
-            "?id_type=id&source=hf&domain=Hawaii&layers=divides&layers=flowpaths&layers=network&layers=nexus"
+            "?id_type=flowpath_id&source=hf&domain=Hawaii&layers=divides&layers=flowpaths&layers=network&layers=nexus"
         )
         assert response.status_code == 200
 
     def test_hydrofabric_non_conus_nhf_returns_501(self, client):
         """Test hydrofabric endpoint returns 501 for non-CONUS domains with NHF."""
         response = client.get(
-            "/v1/hydrofabric/test-id/gpkg?id_type=id&source=nhf&domain=Hawaii&layers=divides"
+            "/v1/hydrofabric/test-id/gpkg?id_type=flowpath_id&source=nhf&domain=Hawaii&layers=divides"
         )
         assert response.status_code == 501
         data = response.json()
@@ -259,7 +259,7 @@ class TestHydrofabricRouterSourceParameter:
 
     def test_hydrofabric_source_without_domain_returns_400(self, client):
         """Test hydrofabric endpoint returns 400 when source provided without domain."""
-        response = client.get("/v1/hydrofabric/test-id/gpkg?id_type=id&source=nhf")
+        response = client.get("/v1/hydrofabric/test-id/gpkg?id_type=flowpath_id&source=nhf")
         assert response.status_code == 400
 
     @pytest.mark.slow
@@ -272,7 +272,7 @@ class TestHydrofabricRouterSourceParameter:
         """
         response = client.get(
             f"/v1/hydrofabric/{watershed_bound_id_good}/gpkg"
-            "?id_type=id&domain=Hawaii&layers=divides&layers=flowpaths&layers=network&layers=nexus"
+            "?id_type=flowpath_id&domain=Hawaii&layers=divides&layers=flowpaths&layers=network&layers=nexus"
         )
         assert response.status_code == 200
 


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions
Changed geopackage API endpoint to use generic names for the ID type field that cover both 2.2 and NHF (as applicable) without referring to specific names in the hydrofabric tables such as hl_uri or site_no.  


## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
