### PR TITLE
sanitize geopackage path and change print statements to log statments

### DIFF
--- a/app/routers/hydrofabric/router.py
+++ b/app/routers/hydrofabric/router.py
@@ -1,4 +1,7 @@
+import logging
+import os
 import pathlib
+import re
 import sqlite3
 import tempfile
 import uuid
@@ -33,6 +36,9 @@ from icefabric.schemas.hydrofabric import (
     IdType,
     QueryIdType,
 )
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 api_router = APIRouter(prefix="/hydrofabric")
 
@@ -95,7 +101,11 @@ async def get_hydrofabric_subset_gpkg(
     """
     unique_id = str(uuid.uuid4())[:8]
     temp_dir = pathlib.Path(tempfile.gettempdir())
-    tmp_path = temp_dir / f"subset_{identifier}_{unique_id}.gpkg"
+    #create sanitized path and filename
+    identifier_clean = re.sub(r"[^A-Za-z0-9_]", "_", identifier)
+    tmp_path = os.path.normpath(temp_dir / f"subset_{identifier_clean}_{unique_id}.gpkg")
+    if not tmp_path.startswith(temp_dir):
+        raise Exception("temporary path for geopackages not allowed")
 
     # Resolve namespace from domain/source combination (outside try block for error handling access)
     try:
@@ -182,13 +192,13 @@ async def get_hydrofabric_subset_gpkg(
                 else:
                     nonspatial_layers[table_name] = layer_data
             else:
-                print(f"Warning: {table_name} layer is empty")
+                logger.warning(f"Warning: {table_name} layer is empty")
 
         # Write spatial layers first with pyogrio
         for table_name, layer_data in spatial_layers.items():
             pyogrio.write_dataframe(layer_data, tmp_path, layer=table_name)
             layers_written += 1
-            print(f"Written spatial layer '{table_name}' with {len(layer_data)} records")
+            logger.info(f"Written spatial layer '{table_name}' with {len(layer_data)} records")
 
         # Then write non-spatial layers with sqlite3
         if nonspatial_layers:
@@ -196,7 +206,7 @@ async def get_hydrofabric_subset_gpkg(
             for table_name, layer_data in nonspatial_layers.items():
                 layer_data.to_sql(table_name, conn, if_exists="replace", index=False)
                 layers_written += 1
-                print(f"Written non-spatial layer '{table_name}' with {len(layer_data)} records")
+                logger.info(f"Written non-spatial layer '{table_name}' with {len(layer_data)} records")
             conn.close()
 
             if layers_written == 0:


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions
The temporary path for storing a subset geopackage uses the id from the API input in the filename.  This was sanitized by only allowing letters and numbers, normalizing the path, and checking against the already defined temp directory root.  
-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
