### PR TITLE
fix: handle rise timeouts so that rise tests skipped if rise api non-functional

### DIFF
--- a/src/icefabric/helpers/rise/rise.py
+++ b/src/icefabric/helpers/rise/rise.py
@@ -45,7 +45,11 @@ async def make_get_req_to_rise(full_url: str):
             resp = await client.get(full_url, headers=RISE_HEADERS, timeout=15)
             resp.raise_for_status()
             rise_response["detail"] = resp.json()
-        except httpx.HTTPError as err:
+        except httpx.TimeoutException as err:
+            print(f"RISE API timed out: {err}")
+            rise_response["status_code"] = 504
+            rise_response["detail"] = "RISE API request timed out"
+        except httpx.HTTPStatusError as err:
             print(f"RISE API returned an HTTP error: {err}")
             rise_response["status_code"] = int(err.response.status_code)
             rise_response["detail"] = err.response.text
@@ -78,7 +82,11 @@ def make_sync_get_req_to_rise(full_url: str) -> dict[str, Any]:
         resp = httpx.get(full_url, headers=RISE_HEADERS, timeout=15)
         resp.raise_for_status()
         rise_response["detail"] = resp.json()
-    except httpx.HTTPError as err:
+    except httpx.TimeoutException as err:
+        print(f"RISE API timed out: {err}")
+        rise_response["status_code"] = 504
+        rise_response["detail"] = "RISE API request timed out"
+    except httpx.HTTPStatusError as err:
         print(f"RISE API returned an HTTP error: {err}")
         rise_response["status_code"] = int(err.response.status_code)
         rise_response["detail"] = err.response.text

--- a/tests/app/test_rise_router.py
+++ b/tests/app/test_rise_router.py
@@ -10,6 +10,14 @@ good_ids = ["10835", "4462", "3672", "3672"]
 
 bad_ids = ["0", "0", "0", "0"]
 
+RISE_TIMEOUT_CODE = 504
+
+
+def _skip_if_rise_unavailable(response):
+    """Skip the test if RISE API is down or timing out."""
+    if response.status_code == RISE_TIMEOUT_CODE:
+        pytest.skip("RISE API is unavailable (timeout)")
+
 
 @pytest.mark.integration
 @pytest.mark.asyncio
@@ -17,6 +25,7 @@ bad_ids = ["0", "0", "0", "0"]
 async def test_get_item_by_id_good(client, resource_type, id):
     """Test all per-ID endpoints for IDs that exist"""
     response = client.get(f"/v1/rise/{resource_type}/{id}")
+    _skip_if_rise_unavailable(response)
     assert response.status_code == 200
     rise_direct_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/{resource_type}/{id}")
     assert json.loads(response.text) == rise_direct_response["detail"]
@@ -28,6 +37,7 @@ async def test_get_item_by_id_good(client, resource_type, id):
 async def test_get_item_by_id_bad(client, resource_type, id):
     """Test all per-ID endpoints for IDs that do not exist"""
     response = client.get(f"/v1/rise/{resource_type}/{id}")
+    _skip_if_rise_unavailable(response)
     assert response.status_code == 404
     rise_direct_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/{resource_type}/{id}")
     assert json.loads(response.text)["detail"] == rise_direct_response["detail"]
@@ -42,6 +52,7 @@ async def test_get_collection(client, resource_type):
     if resource_type == "result":
         pytest.skip(f"Skipping {resource_type} endpoint test until RISE API endpoint stops timing out.")
     response = client.get(f"/v1/rise/{resource_type}")
+    _skip_if_rise_unavailable(response)
     assert response.status_code == 200
     rise_direct_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/{resource_type}")
     assert json.loads(response.text)["data"] == rise_direct_response["detail"]["data"]
@@ -56,6 +67,7 @@ async def test_get_collection_set_of_ids(client, resource_type):
     if resource_type == "result":
         pytest.skip(f"Skipping {resource_type} endpoint test until RISE API endpoint stops timing out.")
     response = client.get(f"/v1/rise/{resource_type}?id=3672,4462,10835")
+    _skip_if_rise_unavailable(response)
     assert response.status_code == 200
     rise_direct_response = await make_get_req_to_rise(
         f"{EXT_RISE_BASE_URL}/{resource_type}?id=3672,4462,10835"


### PR DESCRIPTION
CI/CD wasn't passing whenever RISE api was down. Since this is an external dependency I introduced a bypass in the tests in the event that the RISE api is timing out. I also made it so that if a user hits the icefabric rise endpoints and the rise api times out then the timeout error  is passed through.