### PR TITLE
add domain namespace to cache check if statement

### DIFF
--- a/app/routers/nwm_modules/router.py
+++ b/app/routers/nwm_modules/router.py
@@ -888,7 +888,7 @@ async def get_calibratable_parameter_metadata(
             graph = network_graphs[namespace]
 
     # Use cache catalog if parameter_metadata namespace is cached
-    active_catalog = cache_catalog if "parameter_metadata" in cached_namespaces else catalog
+    active_catalog = cache_catalog if "parameter_metadata" in cached_namespaces and namespace in cached_namespaces else catalog
 
     parameter_metadata = get_parameter_metadata(
         modules=modules,


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

Change if statement that checks for a cached version of the iceberg tables to check for the domain namespace in addition to the parameter_metadata namespace.  Both namespaces need to be available in the cache to run the parameter_metadata endpoint, otherwise the glue catalog needs to be used. 

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
