### PR TITLE
fix: change conus namespace to conus_nhf

### DIFF
--- a/tools/iceberg/build_nhf.py
+++ b/tools/iceberg/build_nhf.py
@@ -39,7 +39,7 @@ def _init(deploy_env: str = "test"):
 
 
 DOMAIN_TO_NAMESPACE = {
-    "conus": "nhf",
+    "conus": "conus_nhf",
     "ak": "ak_nhf",
     "hi": "hi_nhf",
     "prvi": "prvi_nhf",


### PR DESCRIPTION
Changed the mapping of conus domain to be mapped to the conus_nhf namespace rather than nhf
