### PR TITLE
change max character limit for site_no in the streamflow endpoints fr…

### DIFF
--- a/app/routers/streamflow_observations/router.py
+++ b/app/routers/streamflow_observations/router.py
@@ -137,7 +137,7 @@ def get_identifier_info(
     identifier: str = Path(
         ...,
         description="Station/gauge ID",
-        max_length=10,
+        max_length=15,
         pattern=r"^[a-zA-Z0-9]+$",
         examples=["01010000"],
         openapi_examples={"station_example": {"summary": "USGS Gauge", "value": "01010000"}},
@@ -182,7 +182,7 @@ def get_data_time_range(
     identifier: str = Path(
         ...,
         description="Station/gauge ID",
-        max_length=10,
+        max_length=15,
         pattern=r"^[a-zA-Z0-9]+$",
         examples=["01010000"],
         openapi_examples={"station_example": {"summary": "USGS Gauge", "value": "01010000"}},


### PR DESCRIPTION
For the streamflow observations endpoints, the max length of the site_id field needed to be change from 10 to 15 to allow gage 402114105350101.

## Additions

-

## Removals

-

## Changes

Change max_length in the streamflow observation router file from 10 to 15.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
