### PR TITLE
Ngwpc 11078 11080 subsetting error

### DIFF
--- a/src/icefabric/hydrofabric/subset_nhf.py
+++ b/src/icefabric/hydrofabric/subset_nhf.py
@@ -39,17 +39,14 @@ def _build_upstream_dict_from_nexus(
     nexus_to_downstream = fp_pl.select(
         [pl.col(f"up_{node_id}").alias(node_id), pl.col(edge_id).alias(f"dn_{edge_id}")]
     ).filter(pl.col(node_id).is_not_null())
-    nexus_to_downstream.write_csv("down_conus.csv")
 
     nexus_to_upstream = fp_pl.select(
         [pl.col(f"dn_{node_id}").alias(node_id), pl.col(edge_id).alias(f"up_{edge_id}")]
     ).filter(pl.col(node_id).is_not_null())
-    nexus_to_upstream.write_csv("up_conus.csv")
 
     connections = nexus_to_upstream.join(nexus_to_downstream, on=node_id, how="inner").select(
         [pl.col(f"dn_{edge_id}"), pl.col(f"up_{edge_id}")]
     )
-    connections.write_csv("conn_conus.csv")
 
     upstream_dict_df = connections.group_by(f"dn_{edge_id}").agg(
         pl.col(f"up_{edge_id}").sort().alias("upstream_list")

--- a/src/icefabric/hydrofabric/subset_nhf.py
+++ b/src/icefabric/hydrofabric/subset_nhf.py
@@ -39,14 +39,17 @@ def _build_upstream_dict_from_nexus(
     nexus_to_downstream = fp_pl.select(
         [pl.col(f"up_{node_id}").alias(node_id), pl.col(edge_id).alias(f"dn_{edge_id}")]
     ).filter(pl.col(node_id).is_not_null())
+    nexus_to_downstream.write_csv("down_conus.csv")
 
     nexus_to_upstream = fp_pl.select(
         [pl.col(f"dn_{node_id}").alias(node_id), pl.col(edge_id).alias(f"up_{edge_id}")]
     ).filter(pl.col(node_id).is_not_null())
+    nexus_to_upstream.write_csv("up_conus.csv")
 
     connections = nexus_to_upstream.join(nexus_to_downstream, on=node_id, how="inner").select(
         [pl.col(f"dn_{edge_id}"), pl.col(f"up_{edge_id}")]
     )
+    connections.write_csv("conn_conus.csv")
 
     upstream_dict_df = connections.group_by(f"dn_{edge_id}").agg(
         pl.col(f"up_{edge_id}").sort().alias("upstream_list")
@@ -640,7 +643,7 @@ def subset_nhf(
 
     # Build graph for upstream traversal
     logger.debug("Building network graph...")
-    fp_pl = source.load_columns("flowpaths", ["fp_id", "up_nex_id", "dn_nex_id"])
+    fp_pl = source.load_columns("flowpaths", ["fp_id", "up_nex_id", "dn_nex_id", "dn_hydroseq"])
     logger.debug(f"  {len(fp_pl)} flowpaths loaded")
 
     upstream_dict = _build_upstream_dict_from_nexus(fp_pl)
@@ -648,7 +651,20 @@ def subset_nhf(
     logger.debug(f"  Graph: {graph.num_nodes()} nodes, {graph.num_edges()} edges")
 
     if flowpath_id not in node_indices:
-        raise NoResultsFoundError(f"Flowpath {flowpath_id} not found in network.")
+        # check if this is a gage on a flowpath with no up or downstream flowpath
+        if fp_pl.select((pl.col("fp_id") == flowpath_id).any()).item():
+            if (fp_pl.filter(pl.col("fp_id") == flowpath_id).select("dn_hydroseq").item() == 0) and (
+                fp_pl.filter(pl.col("fp_id") == flowpath_id).select("up_nex_id").item() is None
+            ):
+                return generate_subset_from_ids(
+                    source=source,
+                    flowpath_ids={flowpath_id},
+                    subset_file=output,
+                )
+            else:
+                raise NoResultsFoundError(f"Flowpath {flowpath_id} not found in flowpath layer.")
+        else:
+            raise NoResultsFoundError(f"Flowpath {flowpath_id} not found in network.")
 
     output_layers = generate_subset_upstream(
         source=source,

--- a/src/icefabric/hydrofabric/subset_nhf.py
+++ b/src/icefabric/hydrofabric/subset_nhf.py
@@ -651,7 +651,8 @@ def subset_nhf(
     logger.debug(f"  Graph: {graph.num_nodes()} nodes, {graph.num_edges()} edges")
 
     if flowpath_id not in node_indices:
-        # check if this is a gage on a flowpath with no up or downstream flowpath
+        # if the flowpath is not in the graph, it could be a single flowpath
+        # with no up or downstream flowpaths.  If so, just subset for the single flowpath.
         if fp_pl.select((pl.col("fp_id") == flowpath_id).any()).item():
             if (fp_pl.filter(pl.col("fp_id") == flowpath_id).select("dn_hydroseq").item() == 0) and (
                 fp_pl.filter(pl.col("fp_id") == flowpath_id).select("up_nex_id").item() is None


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

If a gage is on a single flowpath with no up or downstream flowpaths, it won't get subset because it's not part of the graph.  In this case, the subset can be done using the single flowpath id.  Added code to handle the case where the flowpath id is not found in the graph then checking to see if the flowpath exists and if it's standalone.  Then subset using just the single flowpath. 

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
