### PR TITLE
Missing gages layer in some geopackages

### DIFF
--- a/src/icefabric/hydrofabric/subset_nhf.py
+++ b/src/icefabric/hydrofabric/subset_nhf.py
@@ -135,7 +135,7 @@ class HydrofabricSource:
         lf = self._get_lazy_frame(layer)
         if lf is None:
             return self._empty_for_layer(layer)
-        return lf.filter(pl.col(col).is_in(ids)).collect()
+        return lf.filter(pl.col(col).cast(pl.Int64).is_in(ids)).collect()
 
     def load_filtered_eq(self, layer: str, col: str, value: str) -> pl.DataFrame:
         """Load a layer filtered by string equality."""


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions
The flowpath IDs returned from the graph are int64 and the fp_id column in the gages layer are float64.   When the int64s are passed into the polars is_in function to filter the gages layer for flowpaths in the subset, there are some times when a flowpath ID isn't return by is_in when it should.  This is likely due to small machine precision level difference in the float64 where it won't equal the int64.  This is only happening when running inside a container.  This PR casts the float64 fp_id column in gages to int64 to match the fp_ids being looked up.  
-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
