### PR TITLE
add function to filter out data outside of the NWM v4 AK domain

### DIFF
--- a/src/icefabric/hydrofabric/subset_nhf.py
+++ b/src/icefabric/hydrofabric/subset_nhf.py
@@ -169,6 +169,25 @@ def pl_to_gdf(pl_df: pl.DataFrame, crs: str = "EPSG:5070") -> gpd.GeoDataFrame:
     return gpd.GeoDataFrame(df, crs=crs)
 
 
+def filter_ak(source: HydrofabricSource, fp_ids: list) -> list:
+    """Get flowpath IDs for divides within the NWM v4 domain""
+
+    Find flowpath ids where isltyp and ivgtyp are both not NA.  These two attributes should
+    not be NA for any catchement within the NWM v4 domain.  From the full list of flowpaths,
+    only keep those where isltyp and ivgtyp are not NA.
+    """
+    div_ids = source.load_columns("divides", ["div_id", "ivgtyp_mode", "isltyp_mode"])
+    div_ids = (
+        div_ids.filter(pl.col("ivgtyp_mode").is_not_null() & pl.col("isltyp_mode").is_not_null())
+        .get_column("div_id")
+        .to_list()
+    )
+
+    div_ids = set(div_ids)
+    has_attr = [item for item in fp_ids if item in div_ids]
+    return has_attr
+
+
 # =============================================================================
 # ID Resolution
 # =============================================================================
@@ -628,6 +647,11 @@ def subset_nhf(
     # ==================================================================
     if vpu_id is not None:
         flowpath_ids = resolve_vpu_to_flowpath_ids(source, vpu_id)
+
+        # If domain is Alaska (vpu 19) only include divides with attributes to match
+        # the NWM v4 Alaska domain.
+        if vpu_id == "19":
+            flowpath_ids = filter_ak(source, flowpath_ids)
 
         output_layers = generate_subset_from_ids(
             source=source,


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions
Add a function to filter out data in the AK NHF that aren't part of the NWM v4 AK domain.  This is done by filtering out flowpaths that have no isltyp and ivgtyp attributes which are only available for the NWM v4 domain.   
-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
